### PR TITLE
Fix codestyle for PHP 7.1

### DIFF
--- a/src/Alcohol.php
+++ b/src/Alcohol.php
@@ -1,19 +1,14 @@
 <?php
-declare(strict_types=1); // must be first line
 
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 
 class Alcohol extends UnsaturatedHydrocarbon implements IAlcohol
 {
-
-    /**
-     * Alcohol constructor.
-     */
-    public function __construct(MoleculeComponent $molecule)
-    {
-        parent::__construct($molecule);
-    }
-
+	public function __construct(MoleculeComponent $molecule)
+	{
+		parent::__construct($molecule);
+	}
 }

--- a/src/Alkane.php
+++ b/src/Alkane.php
@@ -1,110 +1,98 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 
 class Alkane extends SaturatedHydrocarbon implements IAlkane
 {
+	public function __construct(MoleculeComponent $molecule)
+	{
+		parent::__construct($molecule);
+	}
 
-    public function __construct(MoleculeComponent $molecule)
-    {
-        parent::__construct($molecule);
-    }
 
-    public function prefix(int $carbonCount)
-    {
-        $map = array(
-          1 => "meth",
-            2 => "eth",
-            3 => "prop",
-            4 => "but",
-            5 => "pen",
-            6 => "hex",
-            7 => "hep",
-            8 => "oct",
-            9 => "non",
-            10 => "dec",
-            11 => "undec",
-            12 => "dodec",
-            13 => "tridec",
-            14 => "tetradec",
-            15 => "pentadec",
-            16 => "hexadec",
-            17 => "heptadec",
-            18 => "octadec",
-            19 => "nonadec",
-            20 => "eicos"
+	public function prefix(int $carbonCount): array
+	{
+		return [
+			1 => "meth",
+			2 => "eth",
+			3 => "prop",
+			4 => "but",
+			5 => "pen",
+			6 => "hex",
+			7 => "hep",
+			8 => "oct",
+			9 => "non",
+			10 => "dec",
+			11 => "undec",
+			12 => "dodec",
+			13 => "tridec",
+			14 => "tetradec",
+			15 => "pentadec",
+			16 => "hexadec",
+			17 => "heptadec",
+			18 => "octadec",
+			19 => "nonadec",
+			20 => "eicos",
+		];
+	}
 
-        );
-    }
 
-    public function molecularFormula(int $carbonCount)
-    {
+	public function molecularFormula(int $carbonCount)
+	{
 
-    }
+	}
 
-    public function carbonBondAngle()
-    {
-        return 109.5;
-    }
 
-    public function oxidisation()
-    {
-        // TODO: Implement oxidisation() method.
-    }
+	public function carbonBondAngle()
+	{
+		return 109.5;
+	}
 
-    public function oxidisationCallback()
-    {
-        return $this->oxidisation();
-    }
 
-    public function reactions():array
-    {
+	public function oxidisation()
+	{
+		// TODO: Implement oxidisation() method.
+	}
 
-        // Create water molecule
-        $H1 = new Atom("H");
-        $H2 = new Atom("H");
-        $O = new Atom("O");
 
-        // Bonds
-        $H1.addBond(
-            new Bond($O)
-        );
-        $H2.addBond(
-            new Bond($O)
-        );
-        $O.addBond(
-            new Bond($H1)
-        );
-        $O.addBond(
-            new Bond($H2)
-        );
+	public function oxidisationCallback()
+	{
+		return $this->oxidisation();
+	}
 
-        // Create CO2 molecule
-        $C = new Atom("C");
-        $O1 = new Atom("O");
-        $O2 = new Atom("O");
 
-        // Bonds
-        $C.addBond(
-            new Bond($O1)
-        );
-        $C.addBond(
-            new Bond($O2)
-        );
-        $O1.addBond(
-            new Bond($C)
-        );
-        $O2.addBond(
-            new Bond($C)
-        );
+	public function reactions(): array
+	{
+		// Create water molecule
+		$H1 = new Atom("H");
+		$H2 = new Atom("H");
+		$O = new Atom("O");
 
-       return array(
-           "oxidisation" => array(
-               "products"=>array(new Molecule($H1, $H2, $O), new Molecule($C, $O1, $O2)),
-               "reaction"=>$this->oxidisationCallback()
-           )
-       );
-    }
+		// Bonds
+		$H1 . addBond(new Bond($O));
+		$H2 . addBond(new Bond($O));
+		$O . addBond(new Bond($H1));
+		$O . addBond(new Bond($H2));
+
+		// Create CO2 molecule
+		$C = new Atom("C");
+		$O1 = new Atom("O");
+		$O2 = new Atom("O");
+
+		// Bonds
+		$C . addBond(new Bond($O1));
+		$C . addBond(new Bond($O2));
+		$O1 . addBond(new Bond($C));
+		$O2 . addBond(new Bond($C));
+
+		return [
+			"oxidisation" => [
+				"products" => [new Molecule($H1, $H2, $O), new Molecule($C, $O1, $O2)],
+				"reaction" => $this->oxidisationCallback(),
+			],
+		];
+	}
 }

--- a/src/Alkene.php
+++ b/src/Alkene.php
@@ -1,162 +1,173 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
+
 
 use kdaviesnz\atom\Atom;
 use kdaviesnz\atom\IAtom;
 
 class Alkene extends UnsaturatedHydrocarbon implements IAlkene
 {
-    public $carbonAtomWithDoubleBond;
-    public $doubleBond;
+	public $carbonAtomWithDoubleBond;
 
-    /**
-     * Alkene constructor.
-     * @param $carbonAtomWithDoubleBond
-     * @param $doubleBond
-     */
-    public function __construct(MoleculeComponent $molecule)
-    {
-        parent::__construct($molecule);
-        $this->carbonAtomWithDoubleBond = $this->getCarbonAtomWithDoubleBond();
-        $bonds = $this->carbonAtomWithDoubleBond->getBonds();
-        foreach ($bonds as $bond) {
-            $bondedAtom = $bond->getBondedElement();
-            if ($bondedAtom->symbol()=="C" && $bond->getType()=="double") {
-                $this->doubleBond = $bond;
-            }
-        }
-    }
+	public $doubleBond;
 
 
-    public function getCarbonAtomWithDoubleBond():IAtom
-    {
-        $operations = new Operations();
-        $atoms = $this->molecule->getAtoms();
-        $carbonAtoms = array_filter(
-            $atoms,
-            function($atom) use($atoms) {
-                return $atom->symbol() == "C";
-            }
-        );
-
-        foreach ($carbonAtoms as $atom) {
-            $bonds = $atom->getBonds();
-            foreach ($bonds as $bond) {
-                $bondedAtom = $bond->getBondedElement();
-                if ($bondedAtom->symbol()=="C" && $bond->getType()=="double" && $bond->isRecip) {
-                    return $atom;
-                }
-            }
-        }
-
-        if (empty($atom)) {
-            throw new \Exception("Carbon atom with double bond not found in alkene.");
-        }
-        // We should never get here.
-        return $atom;
-    }
-
-    public function hydroboration(): IAlcohol
-    {
-        // TODO: Implement hydroboration() method.
-    }
-
-    public function halogenation(): IMolecule
-    {
-        // TODO: Implement halogenation() method.
-    }
-
-    public function halohydrinformation(): IAlcohol
-    {
-        // TODO: Implement halohydrinformation() method.
-    }
-
-    public function reduction(): IAlkane
-    {
-        // TODO: Implement reduction() method.
-    }
-
-    public function oxidation(): IAlcohol
-    {
-        // TODO: Implement oxidation() method.
-    }
-
-    public function oxymercuration(): IAlcohol
-    {
-        // TODO: Implement oxymercuration() method.
-    }
-
-    /*
-      Alkenes contain a carbon-carbon double bond and, with one double bond and no rings, have the general formula CnH2n
-      The simplist alkene is ethylene
-     */
-    public function molecularFormula(int $carbonCount)
-    {
-
-    }
-
-    public function carbonBondAngle():float
-    {
-        return 120.00;
-    }
+	/**
+	 * @param $carbonAtomWithDoubleBond
+	 * @param $doubleBond
+	 */
+	public function __construct(MoleculeComponent $molecule)
+	{
+		parent::__construct($molecule);
+		$this->carbonAtomWithDoubleBond = $this->getCarbonAtomWithDoubleBond();
+		$bonds = $this->carbonAtomWithDoubleBond->getBonds();
+		foreach ($bonds as $bond) {
+			$bondedAtom = $bond->getBondedElement();
+			if ($bondedAtom->symbol() == "C" && $bond->getType() == "double") {
+				$this->doubleBond = $bond;
+			}
+		}
+	}
 
 
-    public function hydrogenation(IHydrogenHalide $hydrogenHalide): IMolecule
-    {
-/*
-        Steps. IReactionStep
-ref Ionization.php
+	public function getCarbonAtomWithDoubleBond(): IAtom
+	{
+		$operations = new Operations();
+		$atoms = $this->molecule->getAtoms();
+		$carbonAtoms = array_filter(
+			$atoms,
+			function ($atom) use ($atoms) {
+				return $atom->symbol() == "C";
+			}
+		);
 
-    Params: nucleophile with double bond, $hydrogenHalide (both passed by reference)
-    eg CH3CH==CHCH3 + $hydrogenHalide
+		foreach ($carbonAtoms as $atom) {
+			$bonds = $atom->getBonds();
+			foreach ($bonds as $bond) {
+				$bondedAtom = $bond->getBondedElement();
+				if ($bondedAtom->symbol() == "C" && $bond->getType() == "double" && $bond->isRecip) {
+					return $atom;
+				}
+			}
+		}
 
-    Get the π (double) bond (IBond object, by reference) ($carbonCarbonBond)
-    CH3CH == $carbonCarbonBond == CHCH3 + $hydrogenHalide
+		if (empty($atom)) {
+			throw new \Exception("Carbon atom with double bond not found in alkene.");
+		}
 
-    Change $carbonCarbonBond to a single bond eg CH==CH becomesc CH---C
-    CH3CH -- $carbonCarbonBond --- CHCH3 + $hydrogenHalide
-
-    Get the hydrogen atom of $hydrogenHalide  eg "H" of HBR
-    CH3CH -- $carbonCarbonBond --- CHCH3 + $hydrogenHalideHydronAtom - $hydrogenHalideHalogenAtom
-
-    And a new bond from the atom that $carbonCarbonBond points to and point it to $hydrogenHalideHydronAtom
-    CH3CH -- $carbonCarbonBond -- $carbonCarbonBondCarbonAtom --- $carbonHydrogenHalideHalogenAtomBond -- $hydrogenHalideHydronAtom -- $hydrogenHalideHalogenAtom
-
-    Change the atom that B1 points to (A2) to a + ion by subtracting an election (-- valence electrons).
-    $carbonCarbonBondCarbonAtom->valence--
-
-    Add an electron to A1.
-    $hydrogenHalideHydronAtom->valence++
-
-    If A1 now has more than 8 valence electrons then
-        Remove the bond between A1 and the atom it's bonded to (A3)
-        $hydrogenHalide->removeBond()
-
-        Add an atom to A3 to change it to a - ion.
-        $hydrogenHalideHydronAtom->valence++
-
-    Add bond from A3 to A2 (B3)
-    new $hydrogenHalideHydronAtom_CarbonCarbonBondCarbonAtom_bond
-
-    Subtract an electron from A3.
-    $hydrogenHalideHydronAtom--; (no longer an ion)
-    Add an electron to A2.
-    $carbonCarbonBondCarbonAtom++;
-
-*/
-;
-        $reaction = new ElectrophilicAddition($this, $hydrogenHalide, $this->getDoubleBondCarbonAtom(), $hydrogenHalide->getHydrogenAtom(), $this->getDoubleBond(), $hydrogenHalide->getHalideAtom(), $hydrogenHalide->getBond());
-        return $reaction->products;
-
-    }
-
-    public function hydration(ICatalyst $sulfuricAcidCatalyst):IAlcohol
-    {
-        $reaction = new Hydration($this, $water,  $sulfuricAcidCatalyst);
-        return $reaction->products[0];
-    }
+		// We should never get here.
+		return $atom;
+	}
 
 
+	public function hydroboration(): IAlcohol
+	{
+		// TODO: Implement hydroboration() method.
+	}
+
+
+	public function halogenation(): IMolecule
+	{
+		// TODO: Implement halogenation() method.
+	}
+
+
+	public function halohydrinformation(): IAlcohol
+	{
+		// TODO: Implement halohydrinformation() method.
+	}
+
+
+	public function reduction(): IAlkane
+	{
+		// TODO: Implement reduction() method.
+	}
+
+
+	public function oxidation(): IAlcohol
+	{
+		// TODO: Implement oxidation() method.
+	}
+
+
+	public function oxymercuration(): IAlcohol
+	{
+		// TODO: Implement oxymercuration() method.
+	}
+
+
+	/*
+	  Alkenes contain a carbon-carbon double bond and, with one double bond and no rings, have the general formula CnH2n
+	  The simplist alkene is ethylene
+	 */
+	public function molecularFormula(int $carbonCount)
+	{
+
+	}
+
+
+	public function carbonBondAngle(): float
+	{
+		return 120.00;
+	}
+
+
+	public function hydrogenation(IHydrogenHalide $hydrogenHalide): IMolecule
+	{
+		/*
+			Steps. IReactionStep
+			ref Ionization.php
+
+			Params: nucleophile with double bond, $hydrogenHalide (both passed by reference)
+			eg CH3CH==CHCH3 + $hydrogenHalide
+
+			Get the π (double) bond (IBond object, by reference) ($carbonCarbonBond)
+			CH3CH == $carbonCarbonBond == CHCH3 + $hydrogenHalide
+
+			Change $carbonCarbonBond to a single bond eg CH==CH becomesc CH---C
+			CH3CH -- $carbonCarbonBond --- CHCH3 + $hydrogenHalide
+
+			Get the hydrogen atom of $hydrogenHalide  eg "H" of HBR
+			CH3CH -- $carbonCarbonBond --- CHCH3 + $hydrogenHalideHydronAtom - $hydrogenHalideHalogenAtom
+
+			And a new bond from the atom that $carbonCarbonBond points to and point it to $hydrogenHalideHydronAtom
+			CH3CH -- $carbonCarbonBond -- $carbonCarbonBondCarbonAtom --- $carbonHydrogenHalideHalogenAtomBond -- $hydrogenHalideHydronAtom -- $hydrogenHalideHalogenAtom
+
+			Change the atom that B1 points to (A2) to a + ion by subtracting an election (-- valence electrons).
+			$carbonCarbonBondCarbonAtom->valence--
+
+			Add an electron to A1.
+			$hydrogenHalideHydronAtom->valence++
+
+			If A1 now has more than 8 valence electrons then
+				Remove the bond between A1 and the atom it's bonded to (A3)
+				$hydrogenHalide->removeBond()
+
+				Add an atom to A3 to change it to a - ion.
+				$hydrogenHalideHydronAtom->valence++
+
+			Add bond from A3 to A2 (B3)
+			new $hydrogenHalideHydronAtom_CarbonCarbonBondCarbonAtom_bond
+
+			Subtract an electron from A3.
+			$hydrogenHalideHydronAtom--; (no longer an ion)
+			Add an electron to A2.
+			$carbonCarbonBondCarbonAtom++;
+
+		*/;
+		$reaction = new ElectrophilicAddition($this, $hydrogenHalide, $this->getDoubleBondCarbonAtom(), $hydrogenHalide->getHydrogenAtom(), $this->getDoubleBond(), $hydrogenHalide->getHalideAtom(), $hydrogenHalide->getBond());
+
+		return $reaction->products;
+	}
+
+
+	public function hydration(ICatalyst $sulfuricAcidCatalyst): IAlcohol
+	{
+		$reaction = new Hydration($this, $water, $sulfuricAcidCatalyst);
+
+		return $reaction->products[0];
+	}
 }

--- a/src/AlkeneFactory.php
+++ b/src/AlkeneFactory.php
@@ -1,27 +1,23 @@
 <?php
+
 declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
+
 
 use kdaviesnz\atom\IAtom;
 
 class AlkeneFactory extends Factory
 {
-
-    /**
-     * AlkeneFactory constructor.
-     * @param $molecule
-     */
-    public function __construct(array $atoms)
-    {
-        $this->factoryMethod($atoms);
-    }
+	public function __construct(array $atoms)
+	{
+		$this->factoryMethod($atoms);
+	}
 
 
-    protected function factoryMethod(array $atoms)
-    {
-        $this->molecule = new Molecule($atoms);
-        $this->molecule = new Alkene($this->molecule);
-    }
-
+	protected function factoryMethod(array $atoms)
+	{
+		$this->molecule = new Molecule($atoms);
+		$this->molecule = new Alkene($this->molecule);
+	}
 }

--- a/src/AllylicCarbocation.php
+++ b/src/AllylicCarbocation.php
@@ -1,17 +1,18 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 
+/**
+ * If the carbon bearing the positive charge is immediately adjacent to a carbon-carbon double bond,
+ * the carbocation is termed an allylic carbocation. The simplest case (all R = H) is called the allyl carbocation.
+ */
 class AllylicCarbocation extends Carbocation implements IAllylicCarbocation
 {
-    /*
-     If the carbon bearing the positive charge is immediately adjacent to a carbon-carbon double bond, the carbocation is termed an allylic carbocation. The simplest case (all R = H) is called the allyl carbocation.
-     */
-
-    public function __construct(MoleculeComponent $molecule)
-    {
-        parent::__construct($molecule);
-    }
+	public function __construct(MoleculeComponent $molecule)
+	{
+		parent::__construct($molecule);
+	}
 }

--- a/src/ArylCarbocation.php
+++ b/src/ArylCarbocation.php
@@ -1,14 +1,14 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 
-class ArylCarbocation extends Carbocation implements  IArylCarbocation
+class ArylCarbocation extends Carbocation implements IArylCarbocation
 {
-    public function __construct(MoleculeComponent $molecule)
-    {
-        parent::__construct($molecule);
-    }
-
+	public function __construct(MoleculeComponent $molecule)
+	{
+		parent::__construct($molecule);
+	}
 }

--- a/src/BenzylicCarbocation.php
+++ b/src/BenzylicCarbocation.php
@@ -1,15 +1,14 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 
 class BenzylicCarbocation extends Carbocation implements IBenzylicCarbocation
 {
-
-    public function __construct(MoleculeComponent $molecule)
-    {
-        parent::__construct($molecule);
-    }
-
+	public function __construct(MoleculeComponent $molecule)
+	{
+		parent::__construct($molecule);
+	}
 }

--- a/src/Carbocation.php
+++ b/src/Carbocation.php
@@ -1,56 +1,60 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 
+/**
+ * A carbocation is molecule in which a carbon atom bears three bonds and a positive charge.
+ * Carbocations are generally unstable because they do not have eight electrons to satisfy the octet rule.
+ */
 class Carbocation extends MoleculeDecorator implements ICarbocation
 {
-    /*
-     A carbocation is molecule in which a carbon atom bears three bonds and a positive charge. Carbocations are generally unstable because they do not have eight electrons to satisfy the octet rule.
-     */
+	public function __construct(MoleculeComponent $molecule)
+	{
+		$this->molecule = $molecule;
+	}
 
-    /**
-     * Carbocation constructor.
-     */
-    public function __construct(MoleculeComponent $molecule)
-    {
-        $this->molecule = $molecule;
-    }
 
-    public function isElectrophile(): bool
-    {
-        // TODO: Implement isElectrophile() method.
-        return $this->molecule->isElectrophile();
-    }
+	public function isElectrophile(): bool
+	{
+		// TODO: Implement isElectrophile() method.
+		return $this->molecule->isElectrophile();
+	}
 
-    public function isChiral(): bool
-    {
-        // TODO: Implement isChiral() method.
-        return $this->molecule->isChiral();
-    }
 
-    public function getAtoms(): array
-    {
-        // TODO: Implement getAtoms() method.
-        return $this->molecule->getAtoms();
-    }
+	public function isChiral(): bool
+	{
+		// TODO: Implement isChiral() method.
+		return $this->molecule->isChiral();
+	}
 
-    public function getResonanceStructures(): array
-    {
-        // TODO: Implement getResonanceStructures() method.
-        return $this->molecule->getResonanceStructures();
-    }
 
-    public function isNucleophile(): bool
-    {
-        // TODO: Implement isNucleophile() method.
-        return $this->molecule->isNucleophile();
-    }
+	public function getAtoms(): array
+	{
+		// TODO: Implement getAtoms() method.
+		return $this->molecule->getAtoms();
+	}
 
-    public function hasChiralCentre(): bool
-    {
-        // TODO: Implement hasChiralCentre() method.
-        return $this->hasChiralCentre();
-    }
+
+	public function getResonanceStructures(): array
+	{
+		// TODO: Implement getResonanceStructures() method.
+		return $this->molecule->getResonanceStructures();
+	}
+
+
+	public function isNucleophile(): bool
+	{
+		// TODO: Implement isNucleophile() method.
+		return $this->molecule->isNucleophile();
+	}
+
+
+	public function hasChiralCentre(): bool
+	{
+		// TODO: Implement hasChiralCentre() method.
+		return $this->hasChiralCentre();
+	}
 }

--- a/src/Chemical.php
+++ b/src/Chemical.php
@@ -1,353 +1,417 @@
 <?php
-declare(strict_types = 1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 
 class Chemical implements IChemical
 {
-    private $pubChemId = "";
-    private $IUPACName = "";
-    private $InChI = "";
-    private $InChIKey = "";
-    private $CanonicalSMILES = "";
-    private $IsomericSMILES = "";
-    private $MolecularFormula = "";
-    private $MolecularFormulaExpanded = "";
-    private $Description;
-    private $functionalGroups = null;
+	private $pubChemId = "";
 
-    /**
-     * Chemical constructor.
-     * @param string $pubChemId
-     * @param string $IUPACName
-     * @param string $InChI
-     * @param string $InChIKey
-     * @param string $CanonicalSMILES
-     * @param string $IsomericSMILES
-     * @param string $MolecularFormula
-     * @param string $MolecularFormulaExpanded
-     * @param $Description
-     */
-    public function __construct($pubChemId, $IUPACName, $InChI, $InChIKey, $CanonicalSMILES, $IsomericSMILES, $MolecularFormula, $MolecularFormulaExpanded, $Description)
-    {
-        $this->pubChemId = $pubChemId;
-        $this->IUPACName = $IUPACName;
-        $this->InChI = $InChI;
-        $this->InChIKey = $InChIKey;
-        $this->CanonicalSMILES = $CanonicalSMILES;
-        $this->IsomericSMILES = $IsomericSMILES;
-        $this->MolecularFormula = $MolecularFormula;
-        $this->MolecularFormulaExpanded = $MolecularFormulaExpanded;
-        $this->Description = $Description;
-    }
+	private $IUPACName = "";
 
-    /**
-     * @return string
-     */
-    public function getPubChemId()
-    {
-        return $this->pubChemId;
-    }
+	private $InChI = "";
 
-    /**
-     * @return string
-     */
-    public function getIUPACName()
-    {
-        return $this->IUPACName;
-    }
+	private $InChIKey = "";
 
-    /**
-     * @return string
-     */
-    public function getInChI()
-    {
-        return $this->InChI;
-    }
+	private $CanonicalSMILES = "";
 
-    /**
-     * @return string
-     */
-    public function getInChIKey()
-    {
-        return $this->InChIKey;
-    }
+	private $IsomericSMILES = "";
 
-    /**
-     * @return string
-     */
-    public function getCanonicalSMILES()
-    {
-        return $this->CanonicalSMILES;
-    }
+	private $MolecularFormula = "";
 
-    /**
-     * @return string
-     */
-    public function getIsomericSMILES()
-    {
-        return $this->IsomericSMILES;
-    }
+	private $MolecularFormulaExpanded = "";
 
-    /**
-     * @return string
-     */
-    public function getMolecularFormula()
-    {
-        return $this->MolecularFormula;
-    }
+	private $Description;
 
-    /**
-     * @return string
-     */
-    public function getMolecularFormulaExpanded()
-    {
-        return $this->MolecularFormulaExpanded;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getDescription()
-    {
-        return $this->Description;
-    }
-
-    public function getFunctionalGroups($conn)
-    {
-        if (is_null($this->functionalGroups)) {
-            return $this->functionalGroups;
-        }
-
-        // First try to get from database
-
-        // Else get the functional groups from
-        // the info we have and then save them
-        // into the functional_groups table.
-        //   $q = "INSERT INTO `functional_groups` (`pubChemId`, `functional_group`) VALUES ('$pubChemIdSafe', '$functionalGroupSafe');";
-        //   mysqli_query($conn, $q);
+	private $functionalGroups = null;
 
 
-    }
+	/**
+	 * @param string $pubChemId
+	 * @param string $IUPACName
+	 * @param string $InChI
+	 * @param string $InChIKey
+	 * @param string $CanonicalSMILES
+	 * @param string $IsomericSMILES
+	 * @param string $MolecularFormula
+	 * @param string $MolecularFormulaExpanded
+	 * @param $Description
+	 */
+	public function __construct($pubChemId, $IUPACName, $InChI, $InChIKey, $CanonicalSMILES, $IsomericSMILES, $MolecularFormula, $MolecularFormulaExpanded, $Description)
+	{
+		$this->pubChemId = $pubChemId;
+		$this->IUPACName = $IUPACName;
+		$this->InChI = $InChI;
+		$this->InChIKey = $InChIKey;
+		$this->CanonicalSMILES = $CanonicalSMILES;
+		$this->IsomericSMILES = $IsomericSMILES;
+		$this->MolecularFormula = $MolecularFormula;
+		$this->MolecularFormulaExpanded = $MolecularFormulaExpanded;
+		$this->Description = $Description;
+	}
 
-    /**
-     * Hydrocarbons contain just hydrogen and carbon.
-     * @return mixed
-     */
-    public function isHydrocarbon():bool
-    {
-        // Remove numerals from formula.
-        // Remove "C" and "H" from formula
-        // If we are left with an empty string then we have a hydrocarbon
-    }
 
-    /**
-     * Hydrocarbon containing just single bonds.
-     * @return mixed
-     */
-    public function isAlkane():bool
-    {
+	/**
+	 * @return string
+	 */
+	public function getPubChemId()
+	{
+		return $this->pubChemId;
+	}
 
-        // If we have a hydrocarbon
-        //   if SMILE doesnt contain  '=', '#','$','':', '/', '\'
-        //      then we have an alkane
 
-    }
+	/**
+	 * @return string
+	 */
+	public function getIUPACName()
+	{
+		return $this->IUPACName;
+	}
 
-    /**
-     *  A carbonyl group is a C=O group — in other words, a carbon atom double-bonded to oxygen. A carbonyl group is not considered a functional group in itself; instead, it’s considered a component
-     * @return bool
-     */
-    public function isCarbonyl():bool
-    {
-        // If the SMILE contains "C=O" then we have a carbonyl
-    }
 
-    /**
-     * The halides are organic compounds that contain one or more halogens. (Halogens are those elements found in column 7A of the periodic table.)
-     * @return mixed
-     */
-    public function isHalide():bool
-    {
-        // if not hydrocarbon AND formula contains Fl, Cl, Br, I, At or Uus
-        //  then we have a halide
-    }
+	/**
+	 * @return string
+	 */
+	public function getInChI()
+	{
+		return $this->InChI;
+	}
 
-    /**
-     * An alkene is a molecule that contains a carbon-carbon double bond.
-     * @return bool
-     */
-    public function hasAlkeneGroup():bool
-    {
-        // If the SMILE contains "C=C" then we have an alkene group.
-    }
 
-    /**
-     * Alkynes are molecules that contain a carbon-carbon triple bond.
-     * @return bool
-     */
-    public function hasAlkyneGroup():bool
-    {
-        // If the SMILE contains "C#C" then we have an alkyne group.
-    }
+	/**
+	 * @return string
+	 */
+	public function getInChIKey()
+	{
+		return $this->InChIKey;
+	}
 
-    /**
-     * The aromatics (or arenes, as they’re often called) consist of rings containing alternating double bonds. The principal aromatic compound is benzene, a six-carbon ring containing three alternating double bonds.
-     * @return bool
-     */
-    public function hasArmomaticGroup():bool
-    {
-        // If SMILE contains ":"
-        // IF SMILE contains  C1=CC=CC=C1
-        // IF SMILE contains c1ccccc1, n1ccccc1 or o1cccc1
-        // IF SMILE contains c1ccccc1, n1ccccc1 or o1cccc1
-        // IF SMILE contains [nH],  n1c[nH]cc1
-        // IF SMILE contains c1ccccc1-c2ccccc2
-        // IF SMILE contains c1ccccc1c2ccccc2
-        // then we have an aromatic group
 
-    }
+	/**
+	 * @return string
+	 */
+	public function getCanonicalSMILES()
+	{
+		return $this->CanonicalSMILES;
+	}
 
-    /**
-     * Alcohols consist of the general formula R-OH, and have names that end with the suffix –ol.
-     * @return bool
-     */
-    public function hasAlcoholGroup():bool
-    {
-        // Remove numerals from formula
-        // If formula ends in OH then we have an alcohol group
-        // Remove "=", "#", "$" from SMILE.
-        // If SMILE has branches ending in OH then we have an alcohol group
-    }
 
-    /**
-     * Thiols are foul-smelling compounds, of the general formula R-SH. Generally, names of thiols end with the suffix –thiol.
-     * @return bool
-     */
-    public function hasThiolGroup():bool
-    {
-        // Remove numerals from formula
-        // If formula ends in OH then we have an alcohol group
-        // Remove "=", "#", "$" from SMILE.
-        // If SMILE has branches ending in SH then we have an thiol group
+	/**
+	 * @return string
+	 */
+	public function getIsomericSMILES()
+	{
+		return $this->IsomericSMILES;
+	}
 
-    }
 
-    /**
-     * Ethers are molecules containing an oxygen sandwiched between two carbons.
-     * @return bool
-     */
-    public function hasEtherGroup():bool
-    {
-        
-    }
+	/**
+	 * @return string
+	 */
+	public function getMolecularFormula()
+	{
+		return $this->MolecularFormula;
+	}
 
-    /**
-     * In an aldehyde  the carbonyl group is flanked by one hydrogen and one R group. It may be helpful to think of an aldehyde as a carbonyl group at the end of an organic molecule.
-     * @return bool
-     */
-    public function hasAldehydeGroup():bool
-    {
 
-    }
+	/**
+	 * @return string
+	 */
+	public function getMolecularFormulaExpanded()
+	{
+		return $this->MolecularFormulaExpanded;
+	}
 
-    /**
-     * Keytones are compounds that contain a carbonyl group sandwiched between two carbons. If an aldehyde can be thought of as a carbonyl at the end of a molecule, then a ketone is a carbonyl somewhere in the middle of a molecule.
-     * @return bool
-     */
-    public function hasKeynoteGroup():bool
-    {
 
-    }
+	/**
+	 * @return mixed
+	 */
+	public function getDescription()
+	{
+		return $this->Description;
+	}
 
-    /**
-     * The carboxylic acid functional group is made up of a carbonyl group attached to an OH group
-     * @return bool
-     */
-    public function hasCarboxylicAcidGroup():bool
-    {
 
-    }
+	public function getFunctionalGroups($conn)
+	{
+		if (is_null($this->functionalGroups)) {
+			return $this->functionalGroups;
+		}
 
-    /**
-     * An ester is basically a carboxylic acid with the hydrogen snipped off, and an R group glued in its place.
-     * @return bool
-     */
-    public function hasEsterGroup():bool
-    {
+		// First try to get from database
 
-    }
+		// Else get the functional groups from
+		// the info we have and then save them
+		// into the functional_groups table.
+		//   $q = "INSERT INTO `functional_groups` (`pubChemId`, `functional_group`) VALUES ('$pubChemIdSafe', '$functionalGroupSafe');";
+		//   mysqli_query($conn, $q);
 
-    /**
-     * Amides are close relatives of esters, except that amides have a nitrogen (rather than an oxygen) next to the carbonyl group.
-     * @return bool
-     */
-    public function hasAmideGroup():bool
-    {
 
-    }
+	}
 
-    /**
-     * Amines are nitrogen atoms that take the place of a carbon atom in an alkane (the three forms of an amine are R-NH2, R2NH, or R3N). Nicotine as well as many other familiar compounds like cocaine, mescaline, amphetamine, and morphine are all amine-containing compounds. Many drugs (both legal and illegal) contain amines that are essential to the drug’s activity.
-     * @return bool
-     */
-    public function hasAmineGroup():bool
-    {
 
-    }
+	/**
+	 * Hydrocarbons contain just hydrogen and carbon.
+	 *
+	 * @return mixed
+	 */
+	public function isHydrocarbon(): bool
+	{
+		// Remove numerals from formula.
+		// Remove "C" and "H" from formula
+		// If we are left with an empty string then we have a hydrocarbon
+	}
 
-    /**
-     * Nitriles  are compounds that contain a carbon triply bonded to nitrogen.
-     * @return bool
-     */
-    public function hasNitrileGroup():bool
-    {
 
-    }
+	/**
+	 * Hydrocarbon containing just single bonds.
+	 *
+	 * @return mixed
+	 */
+	public function isAlkane(): bool
+	{
 
-    /**
-     * A methyl group is an alkyl derived from methane, containing one carbon atom bondedto three hydrogen atoms — CH3.
-     * @return bool
-     */
-    public function hasMethylGroup():bool
-    {
+		// If we have a hydrocarbon
+		//   if SMILE doesnt contain  '=', '#','$','':', '/', '\'
+		//      then we have an alkane
 
-    }
+	}
 
-    /**
-     * Methylenedioxy is the term used in the field of chemistry, particularly in organic chemistry, for a functional group with the structural formula R-O-CH2-O-R' which is connected to the rest of a molecule by two chemical bonds.
-     * @return bool
-     */
-    public function hasMethylenedioxyGroup():bool
-    {
 
-    }
+	/**
+	 *  A carbonyl group is a C=O group — in other words, a carbon atom double-bonded to oxygen. A carbonyl group is not considered a functional group in itself; instead, it’s considered a component
+	 *
+	 * @return bool
+	 */
+	public function isCarbonyl(): bool
+	{
+		// If the SMILE contains "C=O" then we have a carbonyl
+	}
 
-    /**
-     * In organic chemistry, a methylene bridge, methylene spacer, or methanediyl group is any part of a molecule with formula -CH
-     * @return bool
-     */
-    public function hasMethanediylGroup():bool
-    {
 
-    }
+	/**
+	 * The halides are organic compounds that contain one or more halogens. (Halogens are those elements found in column 7A of the periodic table.)
+	 *
+	 * @return mixed
+	 */
+	public function isHalide(): bool
+	{
+		// if not hydrocarbon AND formula contains Fl, Cl, Br, I, At or Uus
+		//  then we have a halide
+	}
 
-    /**
-     * In organic chemistry, the phenyl group or phenyl ring is a cyclic group of atoms with the formula C6H5. Phenyl groups are closely related to benzene and can be viewed as a benzene ring, minus a hydrogen,which maybe replaced my some other element or compound to serve as a functional group.
-     * @return bool
-     */
-    public function hasPhenylGroup():bool
-    {
 
-    }
+	/**
+	 * An alkene is a molecule that contains a carbon-carbon double bond.
+	 *
+	 * @return bool
+	 */
+	public function hasAlkeneGroup(): bool
+	{
+		// If the SMILE contains "C=C" then we have an alkene group.
+	}
 
-    /**
-     * Amphetamines are a group of synthetic psychoactive drugs called central nervous system (CNS) stimulants.1The collective group of amphetamines includes amphetamine, dextroamphetamine, and methamphetamine.2 Amphetamine is made up of two distinct compounds: pure dextroamphetamine and pure levoamphetamine.
-     * @return bool
-     */
-    public function isAmphetmine():bool
-    {
 
-    }
+	/**
+	 * Alkynes are molecules that contain a carbon-carbon triple bond.
+	 *
+	 * @return bool
+	 */
+	public function hasAlkyneGroup(): bool
+	{
+		// If the SMILE contains "C#C" then we have an alkyne group.
+	}
+
+
+	/**
+	 * The aromatics (or arenes, as they’re often called) consist of rings containing alternating double bonds. The principal aromatic compound is benzene, a six-carbon ring containing three alternating double bonds.
+	 *
+	 * @return bool
+	 */
+	public function hasArmomaticGroup(): bool
+	{
+		// If SMILE contains ":"
+		// IF SMILE contains  C1=CC=CC=C1
+		// IF SMILE contains c1ccccc1, n1ccccc1 or o1cccc1
+		// IF SMILE contains c1ccccc1, n1ccccc1 or o1cccc1
+		// IF SMILE contains [nH],  n1c[nH]cc1
+		// IF SMILE contains c1ccccc1-c2ccccc2
+		// IF SMILE contains c1ccccc1c2ccccc2
+		// then we have an aromatic group
+
+	}
+
+
+	/**
+	 * Alcohols consist of the general formula R-OH, and have names that end with the suffix –ol.
+	 *
+	 * @return bool
+	 */
+	public function hasAlcoholGroup(): bool
+	{
+		// Remove numerals from formula
+		// If formula ends in OH then we have an alcohol group
+		// Remove "=", "#", "$" from SMILE.
+		// If SMILE has branches ending in OH then we have an alcohol group
+	}
+
+
+	/**
+	 * Thiols are foul-smelling compounds, of the general formula R-SH. Generally, names of thiols end with the suffix –thiol.
+	 *
+	 * @return bool
+	 */
+	public function hasThiolGroup(): bool
+	{
+		// Remove numerals from formula
+		// If formula ends in OH then we have an alcohol group
+		// Remove "=", "#", "$" from SMILE.
+		// If SMILE has branches ending in SH then we have an thiol group
+
+	}
+
+
+	/**
+	 * Ethers are molecules containing an oxygen sandwiched between two carbons.
+	 *
+	 * @return bool
+	 */
+	public function hasEtherGroup(): bool
+	{
+
+	}
+
+
+	/**
+	 * In an aldehyde  the carbonyl group is flanked by one hydrogen and one R group. It may be helpful to think of an aldehyde as a carbonyl group at the end of an organic molecule.
+	 *
+	 * @return bool
+	 */
+	public function hasAldehydeGroup(): bool
+	{
+
+	}
+
+
+	/**
+	 * Keytones are compounds that contain a carbonyl group sandwiched between two carbons. If an aldehyde can be thought of as a carbonyl at the end of a molecule, then a ketone is a carbonyl somewhere in the middle of a molecule.
+	 *
+	 * @return bool
+	 */
+	public function hasKeynoteGroup(): bool
+	{
+
+	}
+
+
+	/**
+	 * The carboxylic acid functional group is made up of a carbonyl group attached to an OH group
+	 *
+	 * @return bool
+	 */
+	public function hasCarboxylicAcidGroup(): bool
+	{
+
+	}
+
+
+	/**
+	 * An ester is basically a carboxylic acid with the hydrogen snipped off, and an R group glued in its place.
+	 *
+	 * @return bool
+	 */
+	public function hasEsterGroup(): bool
+	{
+
+	}
+
+
+	/**
+	 * Amides are close relatives of esters, except that amides have a nitrogen (rather than an oxygen) next to the carbonyl group.
+	 *
+	 * @return bool
+	 */
+	public function hasAmideGroup(): bool
+	{
+
+	}
+
+
+	/**
+	 * Amines are nitrogen atoms that take the place of a carbon atom in an alkane (the three forms of an amine are R-NH2, R2NH, or R3N). Nicotine as well as many other familiar compounds like cocaine, mescaline, amphetamine, and morphine are all amine-containing compounds. Many drugs (both legal and illegal) contain amines that are essential to the drug’s activity.
+	 *
+	 * @return bool
+	 */
+	public function hasAmineGroup(): bool
+	{
+
+	}
+
+
+	/**
+	 * Nitriles  are compounds that contain a carbon triply bonded to nitrogen.
+	 *
+	 * @return bool
+	 */
+	public function hasNitrileGroup(): bool
+	{
+
+	}
+
+
+	/**
+	 * A methyl group is an alkyl derived from methane, containing one carbon atom bondedto three hydrogen atoms — CH3.
+	 *
+	 * @return bool
+	 */
+	public function hasMethylGroup(): bool
+	{
+
+	}
+
+
+	/**
+	 * Methylenedioxy is the term used in the field of chemistry, particularly in organic chemistry, for a functional group with the structural formula R-O-CH2-O-R' which is connected to the rest of a molecule by two chemical bonds.
+	 *
+	 * @return bool
+	 */
+	public function hasMethylenedioxyGroup(): bool
+	{
+
+	}
+
+
+	/**
+	 * In organic chemistry, a methylene bridge, methylene spacer, or methanediyl group is any part of a molecule with formula -CH
+	 *
+	 * @return bool
+	 */
+	public function hasMethanediylGroup(): bool
+	{
+
+	}
+
+
+	/**
+	 * In organic chemistry, the phenyl group or phenyl ring is a cyclic group of atoms with the formula C6H5. Phenyl groups are closely related to benzene and can be viewed as a benzene ring, minus a hydrogen,which maybe replaced my some other element or compound to serve as a functional group.
+	 *
+	 * @return bool
+	 */
+	public function hasPhenylGroup(): bool
+	{
+
+	}
+
+
+	/**
+	 * Amphetamines are a group of synthetic psychoactive drugs called central nervous system (CNS) stimulants.1The collective group of amphetamines includes amphetamine, dextroamphetamine, and methamphetamine.2 Amphetamine is made up of two distinct compounds: pure dextroamphetamine and pure levoamphetamine.
+	 *
+	 * @return bool
+	 */
+	public function isAmphetmine(): bool
+	{
+
+	}
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -1,17 +1,22 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
+
 
 use kdaviesnz\atom\IAtom;
 
 abstract class Factory
 {
-    protected abstract function factoryMethod(array $atoms);
-    protected $molecule;
+	protected $molecule;
 
-    public function getMolecule():IMolecule
-    {
-        return $this->molecule;
-    }
+
+	public function getMolecule(): IMolecule
+	{
+		return $this->molecule;
+	}
+
+
+	protected abstract function factoryMethod(array $atoms);
 }

--- a/src/FactoryClient.php
+++ b/src/FactoryClient.php
@@ -1,54 +1,54 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 
-
 use kdaviesnz\atom\Atom;
 use kdaviesnz\atom\Bond;
-use phpDocumentor\Reflection\Types\Integer;
 
 class FactoryClient
 {
-
-    private $operations;
-
-    /**
-     * FactoryClient constructor.
-     */
-    public function getMolecule(string $canonicalSMILE)
-    {
-
-        $this->operations = new Operations();
-
-        $atoms = array();
-
-        // Recursive. $atoms is passed by reference.
-        $this->operations->addBranches($canonicalSMILE, $atoms);
-
-        $this->operations->addLoopBonds($atoms);
-
-        $this->operations->atomsToCanonicalSMILE($atoms);
+	/** @var array */
+	private $operations;
 
 
-        $factoryType = "";
+	/**
+	 * FactoryClient constructor.
+	 */
+	public function getMolecule(string $canonicalSMILE)
+	{
 
-        // Logic to determine what type of factory eg AlkeneFactory, AmineFactory, MoleculeFactory
-        if (strpos($canonicalSMILE, "C=C")!==false) {
-            $factoryType = "AlkeneFactory";
-        }
+		$this->operations = new Operations();
 
-        switch($factoryType) {
-            case "AlkeneFactory":
-                $factory = new AlkeneFactory($atoms);
-                break;
-            default:
-                $factory = new MoleculeFactory($atoms);
-                break;
-        }
-        $molecule = $factory->getMolecule();
-        return $molecule;
-    }
+		$atoms = [];
 
+		// Recursive. $atoms is passed by reference.
+		$this->operations->addBranches($canonicalSMILE, $atoms);
+
+		$this->operations->addLoopBonds($atoms);
+
+		$this->operations->atomsToCanonicalSMILE($atoms);
+
+
+		$factoryType = "";
+
+		// Logic to determine what type of factory eg AlkeneFactory, AmineFactory, MoleculeFactory
+		if (strpos($canonicalSMILE, "C=C") !== false) {
+			$factoryType = "AlkeneFactory";
+		}
+
+		switch ($factoryType) {
+			case "AlkeneFactory":
+				$factory = new AlkeneFactory($atoms);
+				break;
+			default:
+				$factory = new MoleculeFactory($atoms);
+				break;
+		}
+		$molecule = $factory->getMolecule();
+
+		return $molecule;
+	}
 }

--- a/src/FunctionalGroup.php
+++ b/src/FunctionalGroup.php
@@ -1,86 +1,93 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 
 class FunctionalGroup extends MoleculeDecorator implements IFunctionalGroup
 {
-
-    /**
-     * FunctionalGroup constructor.
-     */
-    public function __construct(MoleculeComponent $molecule)
-    {
-        $this->molecule = $molecule;
-    }
-
-    public function reactions(): array
-    {
-
-    }
-
-    public function hydrogenCount(int $carbonCount)
-    {
-        // TODO: Implement hydrogenCount() method.
-    }
-
-    public function molecularFormula(int $carbonCount)
-    {
-        // TODO: Implement molecularFormula() method.
-    }
-
-    public function freeRadicalHalogenation(): array
-    {
-        // TODO: Implement freeRadicalHalogenation() method.
-    }
-
-    public function isElectrophile(): bool
-    {
-        // TODO: Implement isElectrophile() method.
-        return $this->molecule->isElectrophile();
-    }
-
-    public function isNucleophile(): bool
-    {
-        // TODO: Implement isNucleophile() method.
-        return $this->molecule->isNucleophile();
-    }
-
-    public function isChiral(): bool
-    {
-        // TODO: Implement isChiral() method.
-        return $this->molecule->isChiral();
-    }
-
-    public function carbonBondAngle()
-    {
-        // TODO: Implement carbonBondAngle() method.
-    }
-
-    public function prefix(int $carbonCount)
-    {
-        // TODO: Implement prefix() method.
-
-    }
-
-    public function hasChiralCentre(): bool
-    {
-        // TODO: Implement hasChiralCentre() method.
-        return $this->molecule->hasChiralCentre();
-    }
-
-    public function getAtoms(): array
-    {
-        // TODO: Implement getAtoms() method.
-        return $this->molecule->getAtoms();
-    }
-
-    public function getResonanceStructures(): array
-    {
-        // TODO: Implement getResonanceStructures() method.
-        return $this->molecule->getResonanceStructures();
-    }
+	public function __construct(MoleculeComponent $molecule)
+	{
+		$this->molecule = $molecule;
+	}
 
 
+	public function reactions(): array
+	{
+
+	}
+
+
+	public function hydrogenCount(int $carbonCount)
+	{
+		// TODO: Implement hydrogenCount() method.
+	}
+
+
+	public function molecularFormula(int $carbonCount)
+	{
+		// TODO: Implement molecularFormula() method.
+	}
+
+
+	public function freeRadicalHalogenation(): array
+	{
+		// TODO: Implement freeRadicalHalogenation() method.
+	}
+
+
+	public function isElectrophile(): bool
+	{
+		// TODO: Implement isElectrophile() method.
+		return $this->molecule->isElectrophile();
+	}
+
+
+	public function isNucleophile(): bool
+	{
+		// TODO: Implement isNucleophile() method.
+		return $this->molecule->isNucleophile();
+	}
+
+
+	public function isChiral(): bool
+	{
+		// TODO: Implement isChiral() method.
+		return $this->molecule->isChiral();
+	}
+
+
+	public function carbonBondAngle()
+	{
+		// TODO: Implement carbonBondAngle() method.
+	}
+
+
+	public function prefix(int $carbonCount)
+	{
+		// TODO: Implement prefix() method.
+
+	}
+
+
+	public function hasChiralCentre(): bool
+	{
+		// TODO: Implement hasChiralCentre() method.
+		return $this->molecule->hasChiralCentre();
+	}
+
+
+	public function getAtoms(): array
+	{
+		// TODO: Implement getAtoms() method.
+		return $this->molecule->getAtoms();
+	}
+
+
+	public function getResonanceStructures(): array
+	{
+		// TODO: Implement getResonanceStructures() method.
+		return $this->molecule->getResonanceStructures();
+	}
 }

--- a/src/Hydrocarbon.php
+++ b/src/Hydrocarbon.php
@@ -1,22 +1,19 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 class Hydrocarbon extends FunctionalGroup implements IHydrocarbon
 {
+	public function __construct(MoleculeComponent $molecule)
+	{
+		parent::__construct($molecule);
+	}
 
-    /**
-     * Hydrocarbon constructor.
-     */
-    public function __construct(MoleculeComponent $molecule)
-    {
-        parent::__construct($molecule);
-    }
 
-    public function reactions(): array
-    {
-        return array();
-    }
-
+	public function reactions(): array
+	{
+		return [];
+	}
 }

--- a/src/HydrogenHalide.php
+++ b/src/HydrogenHalide.php
@@ -1,7 +1,9 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
+
 
 use kdaviesnz\atom\Atom;
 use kdaviesnz\atom\Bond;
@@ -9,19 +11,22 @@ use kdaviesnz\atom\IHalogen;
 
 class HydrogenHalide extends Molecule implements IHydrogenHalide
 {
-    public $hydrogenAtom;
-    public $halogenAtom;
-    /**
-     * HydrogenHalide constructor.
-     */
-    public function __construct(MoleculeComponent $molecule, IHalogen $halogen)
-    {
-        parent::__construct($molecule);
+	public $hydrogenAtom;
 
-        $this->halogenAtom = $halogen;
-        $this->hydrogenAtom = new Atom("H");
-        $this->hydrogenAtom->addBond(new Bond($halogen, "single"));
-        $halogen->addBond(new Bond($this->hydrogenAtom, "single", uniqid()));
-        parent::__construct(new Atom("H"), $halogen);
-    }
+	public $halogenAtom;
+
+
+	/**
+	 * HydrogenHalide constructor.
+	 */
+	public function __construct(MoleculeComponent $molecule, IHalogen $halogen)
+	{
+		parent::__construct($molecule);
+
+		$this->halogenAtom = $halogen;
+		$this->hydrogenAtom = new Atom("H");
+		$this->hydrogenAtom->addBond(new Bond($halogen, "single"));
+		$halogen->addBond(new Bond($this->hydrogenAtom, "single", uniqid()));
+		parent::__construct(new Atom("H"), $halogen);
+	}
 }

--- a/src/IAlcohol.php
+++ b/src/IAlcohol.php
@@ -1,10 +1,10 @@
 <?php
 
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 
 interface IAlcohol
 {
-
 }

--- a/src/IAlkane.php
+++ b/src/IAlkane.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
@@ -7,13 +8,14 @@ namespace kdaviesnz\molecule;
 interface IAlkane
 {
 
-    /*
-     The oxidation of alkanes by O2 to give carbon dioxide and water is by far their most economically important reaction. Oxidation of saturated hydrocarbons is the basis for their use as energy sources for heat [natural gas, liquefied petroleum gas (LPG), and fuel oil] and power (gasoline, diesel fuel, and aviation fuel). Following are balanced equations for the complete oxidation of methane (the major component of natural gas) and propane (the major component of LPG).
-CH4 1 2O2 h CO2 1 2H2O
-     Organic Chemistry 8th edition
-     */
-    public function oxidisation();
-
-
-
+	/**
+	 * The oxidation of alkanes by O2 to give carbon dioxide and water is by far their most economically important reaction.
+	 *
+	 * Oxidation of saturated hydrocarbons is the basis for their use as energy sources for heat
+	 * [natural gas, liquefied petroleum gas (LPG), and fuel oil] and power (gasoline, diesel fuel, and aviation fuel).
+	 * Following are balanced equations for the complete oxidation of methane (the major component of natural gas) and propane (the major component of LPG).
+	 * CH4 1 2O2 h CO2 1 2H2O
+	 * Organic Chemistry 8th edition
+	 */
+	public function oxidisation();
 }

--- a/src/IAlkene.php
+++ b/src/IAlkene.php
@@ -1,67 +1,77 @@
 <?php
 
+declare(strict_types=1);
+
 namespace kdaviesnz\molecule;
+
 
 use kdaviesnz\atom\IAtom;
 
 interface IAlkene
 {
 
-    public function getCarbonAtomWithDoubleBond():IAtom;
+	public function getCarbonAtomWithDoubleBond(): IAtom;
 
-    /*
+	/*
  The most characteristic reaction of alkenes is addition to the carbon-carbon dou- ble bond in such a way that the p bond is broken and, in its place, s bonds form to two new atoms or groups of atoms. Table 6.1 gives several examples of reactions at a carbon-carbon double bond along with the descriptive name(s) associated with each. Some of these reactions are treated separately under oxidations (Section 6.5) and reductions (Section 6.6), but are included in this table because they are formally additions.
  */
-    /*
-     alkene + HX (X=halogen) -> Single carbon-carbon bond, X bonded to a C, H bonded to other C.
+	/*
+	 alkene + HX (X=halogen) -> Single carbon-carbon bond, X bonded to a C, H bonded to other C.
 
 The hydrogen halides HCl, HBr, and HI add to alkenes to give haloalkanes (alkyl halides). These additions may be carried out either with the pure reagents (neat) or in the presence of a polar solvent such as acetic acid. HCl reacts sluggishly compared to the other two acids. Addition of HBr to ethylene gives bromoethane (ethyl bromide).
 
 
-    Organic Chemistry 8th edition
-     */
-    public function hydrogenation(IHydrogenHalide $hydrogenHalide): IMolecule;
+	Organic Chemistry 8th edition
+	 */
+	public function hydrogenation(IHydrogenHalide $hydrogenHalide): IMolecule;
 
-    /*
-    alkene + H2O + acid catalyst (eg sufuric acid) -> As above but with (OH) bonded to a C.
-     */
-    public function hydration(ICatalyst $sulfuricAcidCatalyst): IAlcohol;
 
-    /*
-     alkene + X2 -> As above but with X bonded to C and X bonded to other C.
-     */
-    public function halogenation(): IMolecule;
+	/*
+	alkene + H2O + acid catalyst (eg sufuric acid) -> As above but with (OH) bonded to a C.
+	 */
+	public function hydration(ICatalyst $sulfuricAcidCatalyst): IAlcohol;
 
-    /*
-     alkene + X2 + H20 -> As above but with X bonded to C and (OH) bonded to other C.
-    */
-    public function halohydrinformation(): IAlcohol;
 
-    /*
-     alkene + Hg(OAc)2 + H2O -> As above but with HO bonded to C and HgOAc bonded to other C.
-     */
-    public function oxymercuration(): IAlcohol;
+	/*
+	 alkene + X2 -> As above but with X bonded to C and X bonded to other C.
+	 */
+	public function halogenation(): IMolecule;
 
-    /*
-     alkene + BH3 -> As above but with HO bonded to C and BH2 bonded to other C.
-     */
-    public function hydroboration():IAlcohol;
 
-    /*
-     alkene + OsO4 -> As above but with HO bonded to C and HO bonded to other C.
-     */
-    public function oxidation():IAlcohol;
+	/*
+	 alkene + X2 + H20 -> As above but with X bonded to C and (OH) bonded to other C.
+	*/
+	public function halohydrinformation(): IAlcohol;
 
-    /*
-     alkene + H2 + transition metal catalyst eg Pd -> As above but with H bonded to C and H bonded to other C.
-     */
-    public function reduction():IAlkane;
 
-    /*
-     In chemistry, pi bonds (π bonds) are covalent chemical bonds where two lobes of an orbital on one atom overlap two lobes of an orbital on another atom. Each of these atomic orbitals is zero at a shared nodal plane, passing through the two bonded nuclei. The same plane is also a nodal plane for the molecular orbital of the pi bond.
+	/*
+	 alkene + Hg(OAc)2 + H2O -> As above but with HO bonded to C and HgOAc bonded to other C.
+	 */
+	public function oxymercuration(): IAlcohol;
 
-    In chemistry, sigma bonds (σ bonds) are the strongest type of covalent chemical bond. They are formed by head-on overlapping between atomic orbitals. Sigma bonding is most simply defined for diatomic molecules using the language and tools of symmetry groups.
-     */
+
+	/*
+	 alkene + BH3 -> As above but with HO bonded to C and BH2 bonded to other C.
+	 */
+	public function hydroboration(): IAlcohol;
+
+
+	/*
+	 alkene + OsO4 -> As above but with HO bonded to C and HO bonded to other C.
+	 */
+	public function oxidation(): IAlcohol;
+
+
+	/*
+	 alkene + H2 + transition metal catalyst eg Pd -> As above but with H bonded to C and H bonded to other C.
+	 */
+	public function reduction(): IAlkane;
+
+	/*
+	 In chemistry, pi bonds (π bonds) are covalent chemical bonds where two lobes of an orbital on one atom overlap two lobes of an orbital on another atom. Each of these atomic orbitals is zero at a shared nodal plane, passing through the two bonded nuclei. The same plane is also a nodal plane for the molecular orbital of the pi bond.
+
+	In chemistry, sigma bonds (σ bonds) are the strongest type of covalent chemical bond. They are formed by head-on overlapping between atomic orbitals. Sigma bonding is most simply defined for diatomic molecules using the language and tools of symmetry groups.
+	 */
 
 }
 

--- a/src/IAllylicCarbocation.php
+++ b/src/IAllylicCarbocation.php
@@ -1,9 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace kdaviesnz\molecule;
 
 
 interface IAllylicCarbocation
 {
-
 }

--- a/src/IArylCarbocation.php
+++ b/src/IArylCarbocation.php
@@ -1,10 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace kdaviesnz\molecule;
 
+
+/**
+ * If the carbon bearing the positive charge is part of a benzene ring,
+ * the carbocation is termed an aryl carbocation.
+ * The simplest case is called the phenyl carbocation.
+ */
 interface IArylCarbocation
 {
-    /*
-     If the carbon bearing the positive charge is part of a benzene ring, the carbocation is termed an aryl carbocation. The simplest case is called the phenyl carbocation.
-     */
 }

--- a/src/IBenzylicCarbocation.php
+++ b/src/IBenzylicCarbocation.php
@@ -1,12 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace kdaviesnz\molecule;
 
 
+/**
+ * If the carbon bearing the positive charge is immediately adjacent to a benzene ring,
+ * the carbocation is termed a benzylic carbocation.
+ * The simplest case is called the benzyl carbocation.
+ */
 interface IBenzylicCarbocation
 {
-    /*
-     If the carbon bearing the positive charge is immediately adjacent to a benzene ring, the carbocation is termed a benzylic carbocation. The simplest case is called the benzyl carbocation.
-
-     */
 }

--- a/src/ICarbocation.php
+++ b/src/ICarbocation.php
@@ -1,9 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace kdaviesnz\molecule;
 
 
 interface ICarbocation
 {
-
 }

--- a/src/IChemical.php
+++ b/src/IChemical.php
@@ -1,255 +1,298 @@
 <?php
 
+declare(strict_types=1);
+
 namespace kdaviesnz\molecule;
 
-/**
- * Interface IChemical
- */
 interface IChemical
 {
 
-    /*
-     * ref https://en.wikipedia.org/wiki/Substituted_phenethylamine
-     */
-    public function isPhenethylamine();
-
-    /**
-     * Hydrocarbons contain just hydrogen and carbon.
-     * @return mixed
-     */
-    public function isHydrocarbon():bool;
-
-    /**
-     * Hydrocarbon containing just single bonds.
-     * Formula CnH2n+1
-     * @return mixed
-     */
-    public function isAlkane():bool;
-
-    /**
-     *  A carbonyl group is a C=O group — in other words, a carbon atom double-bonded to oxygen. A carbonyl group is not considered a functional group in itself; instead, it’s considered a component
-     * @return bool
-     */
-    public function isCarbonyl():bool;
-
-    /**
-     * The halides are organic compounds that contain one or more halogens. (Halogens are those elements found in column 7A of the periodic table.)
-     * @return mixed
-     */
-    public function isHalide():bool;
-
-    /**
-     * An alkene is a molecule that contains a carbon-carbon double bond.
-     * @return bool
-     */
-    public function hasAlkeneGroup():bool;
-
-    /**
-     * Alkynes are molecules that contain a carbon-carbon triple bond.
-     * @return bool
-     */
-    public function hasAlkyneGroup():bool;
-
-    /**
-     * The aromatics (or arenes, as they’re often called) consist of rings containing alternating double bonds. The principal aromatic compound is benzene, a six-carbon ring containing three alternating double bonds.
-     * @return bool
-     */
-    public function hasArmomaticGroup():bool;
-
-    /**
-     * Alcohols consist of the general formula R-OH, and have names that end with the suffix –ol.
-     * @return bool
-     */
-    public function hasAlcoholGroup():bool;
-
-    /**
-     * Thiols are foul-smelling compounds, of the general formula R-SH. Generally, names of thiols end with the suffix –thiol.
-     * @return bool
-     */
-    public function hasThiolGroup():bool;
-
-    /**
-     * Ethers are molecules containing an oxygen sandwiched between two carbons.
-     * @return bool
-     */
-    public function hasEtherGroup():bool;
-
-    /**
-     * In an aldehyde  the carbonyl group is flanked by one hydrogen and one R group. It may be helpful to think of an aldehyde as a carbonyl group at the end of an organic molecule.
-     * @return bool
-     */
-    public function hasAldehydeGroup():bool;
-
-    /**
-     * Keytones are compounds that contain a carbonyl group sandwiched between two carbons. If an aldehyde can be thought of as a carbonyl at the end of a molecule, then a ketone is a carbonyl somewhere in the middle of a molecule.
-     * @return bool
-     */
-    public function hasKeynoteGroup():bool;
-
-    /**
-     * The carboxylic acid functional group is made up of a carbonyl group attached to an OH group
-     * @return bool
-     */
-    public function hasCarboxylicAcidGroup():bool;
-
-    /**
-     * An ester is basically a carboxylic acid with the hydrogen snipped off, and an R group glued in its place.
-     * @return bool
-     */
-    public function hasEsterGroup():bool;
-
-    /**
-     * Amides are close relatives of esters, except that amides have a nitrogen (rather than an oxygen) next to the carbonyl group.
-     * @return bool
-     */
-    public function hasAmideGroup():bool;
-
-    /**
-     * Amines are nitrogen atoms that take the place of a carbon atom in an alkane (the three forms of an amine are R-NH2, R2NH, or R3N). Nicotine as well as many other familiar compounds like cocaine, mescaline, amphetamine, and morphine are all amine-containing compounds. Many drugs (both legal and illegal) contain amines that are essential to the drug’s activity.
-     * @return bool
-     */
-    public function hasAmineGroup():bool;
-
-    /**
-     * Nitriles  are compounds that contain a carbon triply bonded to nitrogen.
-     * @return bool
-     */
-    public function hasNitrileGroup():bool;
-
-    /**
-     * A methyl group is an alkyl derived from methane, containing one carbon atom bondedto three hydrogen atoms — CH3.
-     * @return bool
-     */
-    public function hasMethylGroup():bool;
-
-    /**
-     * Methylenedioxy is the term used in the field of chemistry, particularly in organic chemistry, for a functional group with the structural formula R-O-CH2-O-R' which is connected to the rest of a molecule by two chemical bonds.
-     * @return bool
-     */
-    public function hasMethylenedioxyGroup():bool;
-
-    /**
-     * In organic chemistry, a methylene bridge, methylene spacer, or methanediyl group is any part of a molecule with formula -CH
-     * @return bool
-     */
-    public function hasMethanediylGroup():bool;
-
-    /**
-     * In organic chemistry, the phenyl group or phenyl ring is a cyclic group of atoms with the formula C6H5. Phenyl groups are closely related to benzene and can be viewed as a benzene ring, minus a hydrogen,which maybe replaced my some other element or compound to serve as a functional group.
-     * @return bool
-     */
-    public function hasPhenylGroup():bool;
-
-    /**
-     * Amphetamines are a group of synthetic psychoactive drugs called central nervous system (CNS) stimulants.1The collective group of amphetamines includes amphetamine, dextroamphetamine, and methamphetamine.2 Amphetamine is made up of two distinct compounds: pure dextroamphetamine and pure levoamphetamine.
-     * @return bool
-     */
-    public function isAmphetmine():bool;
+	/**
+	 * @link https://en.wikipedia.org/wiki/Substituted_phenethylamine
+	 */
+	public function isPhenethylamine();
 
 
-    /*
-     “t’s easy to call a molecule an acid or a base, and say, “That’s all there is to it, folks.” But the terms acid and base are a little more elusive. A molecule is an acid only in comparison to another molecule, and likewise for a base. When the terms acid or base are used when discussing a particular molecule, they’re used in comparison to a reference molecule — water. Water is capable of acting both as an acid and as a base. Any molecule that’s more acidic than water is generally considered an acid, and any molecule that’s more basic than water is generally considered a base.
+	/**
+	 * Hydrocarbons contain just hydrogen and carbon.
+	 *
+	 * @return mixed
+	 */
+	public function isHydrocarbon(): bool;
+
+
+	/**
+	 * Hydrocarbon containing just single bonds.
+	 * Formula CnH2n+1
+	 *
+	 * @return mixed
+	 */
+	public function isAlkane(): bool;
+
+
+	/**
+	 *  A carbonyl group is a C=O group — in other words, a carbon atom double-bonded to oxygen. A carbonyl group is not considered a functional group in itself; instead, it’s considered a component
+	 *
+	 * @return bool
+	 */
+	public function isCarbonyl(): bool;
+
+
+	/**
+	 * The halides are organic compounds that contain one or more halogens. (Halogens are those elements found in column 7A of the periodic table.)
+	 *
+	 * @return mixed
+	 */
+	public function isHalide(): bool;
+
+
+	/**
+	 * An alkene is a molecule that contains a carbon-carbon double bond.
+	 *
+	 * @return bool
+	 */
+	public function hasAlkeneGroup(): bool;
+
+
+	/**
+	 * Alkynes are molecules that contain a carbon-carbon triple bond.
+	 *
+	 * @return bool
+	 */
+	public function hasAlkyneGroup(): bool;
+
+
+	/**
+	 * The aromatics (or arenes, as they’re often called) consist of rings containing alternating double bonds. The principal aromatic compound is benzene, a six-carbon ring containing three alternating double bonds.
+	 *
+	 * @return bool
+	 */
+	public function hasArmomaticGroup(): bool;
+
+
+	/**
+	 * Alcohols consist of the general formula R-OH, and have names that end with the suffix –ol.
+	 *
+	 * @return bool
+	 */
+	public function hasAlcoholGroup(): bool;
+
+
+	/**
+	 * Thiols are foul-smelling compounds, of the general formula R-SH. Generally, names of thiols end with the suffix –thiol.
+	 *
+	 * @return bool
+	 */
+	public function hasThiolGroup(): bool;
+
+
+	/**
+	 * Ethers are molecules containing an oxygen sandwiched between two carbons.
+	 *
+	 * @return bool
+	 */
+	public function hasEtherGroup(): bool;
+
+
+	/**
+	 * In an aldehyde  the carbonyl group is flanked by one hydrogen and one R group. It may be helpful to think of an aldehyde as a carbonyl group at the end of an organic molecule.
+	 *
+	 * @return bool
+	 */
+	public function hasAldehydeGroup(): bool;
+
+
+	/**
+	 * Keytones are compounds that contain a carbonyl group sandwiched between two carbons. If an aldehyde can be thought of as a carbonyl at the end of a molecule, then a ketone is a carbonyl somewhere in the middle of a molecule.
+	 *
+	 * @return bool
+	 */
+	public function hasKeynoteGroup(): bool;
+
+
+	/**
+	 * The carboxylic acid functional group is made up of a carbonyl group attached to an OH group
+	 *
+	 * @return bool
+	 */
+	public function hasCarboxylicAcidGroup(): bool;
+
+
+	/**
+	 * An ester is basically a carboxylic acid with the hydrogen snipped off, and an R group glued in its place.
+	 *
+	 * @return bool
+	 */
+	public function hasEsterGroup(): bool;
+
+
+	/**
+	 * Amides are close relatives of esters, except that amides have a nitrogen (rather than an oxygen) next to the carbonyl group.
+	 *
+	 * @return bool
+	 */
+	public function hasAmideGroup(): bool;
+
+
+	/**
+	 * Amines are nitrogen atoms that take the place of a carbon atom in an alkane (the three forms of an amine are R-NH2, R2NH, or R3N). Nicotine as well as many other familiar compounds like cocaine, mescaline, amphetamine, and morphine are all amine-containing compounds. Many drugs (both legal and illegal) contain amines that are essential to the drug’s activity.
+	 *
+	 * @return bool
+	 */
+	public function hasAmineGroup(): bool;
+
+
+	/**
+	 * Nitriles  are compounds that contain a carbon triply bonded to nitrogen.
+	 *
+	 * @return bool
+	 */
+	public function hasNitrileGroup(): bool;
+
+
+	/**
+	 * A methyl group is an alkyl derived from methane, containing one carbon atom bondedto three hydrogen atoms — CH3.
+	 *
+	 * @return bool
+	 */
+	public function hasMethylGroup(): bool;
+
+
+	/**
+	 * Methylenedioxy is the term used in the field of chemistry, particularly in organic chemistry, for a functional group with the structural formula R-O-CH2-O-R' which is connected to the rest of a molecule by two chemical bonds.
+	 *
+	 * @return bool
+	 */
+	public function hasMethylenedioxyGroup(): bool;
+
+
+	/**
+	 * In organic chemistry, a methylene bridge, methylene spacer, or methanediyl group is any part of a molecule with formula -CH
+	 *
+	 * @return bool
+	 */
+	public function hasMethanediylGroup(): bool;
+
+
+	/**
+	 * In organic chemistry, the phenyl group or phenyl ring is a cyclic group of atoms with the formula C6H5. Phenyl groups are closely related to benzene and can be viewed as a benzene ring, minus a hydrogen,which maybe replaced my some other element or compound to serve as a functional group.
+	 *
+	 * @return bool
+	 */
+	public function hasPhenylGroup(): bool;
+
+
+	/**
+	 * Amphetamines are a group of synthetic psychoactive drugs called central nervous system (CNS) stimulants.1The collective group of amphetamines includes amphetamine, dextroamphetamine, and methamphetamine.2 Amphetamine is made up of two distinct compounds: pure dextroamphetamine and pure levoamphetamine.
+	 *
+	 * @return bool
+	 */
+	public function isAmphetmine(): bool;
+
+
+	/*
+	 “t’s easy to call a molecule an acid or a base, and say, “That’s all there is to it, folks.” But the terms acid and base are a little more elusive. A molecule is an acid only in comparison to another molecule, and likewise for a base. When the terms acid or base are used when discussing a particular molecule, they’re used in comparison to a reference molecule — water. Water is capable of acting both as an acid and as a base. Any molecule that’s more acidic than water is generally considered an acid, and any molecule that’s more basic than water is generally considered a base.
 
 But keep in mind that these terms are general. Most people would agree that nitric acid is an acid; its name even includes the word acid. But even nitric acid can act as a base under the right conditions! In the presence of the more acidic sulfuric acid, nitric acid acts as a base (you see this reaction in the nitration of benzene in Chapter 15). This reaction is an extreme case, but I hope it makes you wary of rigidly classifying a molecule as an acid or a base, even though ”
 “doing so is convenient. Whether a molecule acts as an acid or as a base really depends on what’s thrown into the reaction pot along with it.”
 
 Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
 Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
-     */
-    
-    /*
-     * “Svante Arrhenius, a prominent chemist from the early 20th century (whose ideas on acids and bases later earned him the Nobel Prize), defined acids as molecules that dissociate in water to make the hydronium ion, H3O+. Strong Arrhenius acids are those that completely dissociate in water to make hydronium ions, while acids that only partially dissociate in water are said to be weak Arrhenius acids. Nitric acid (HNO3), shown in Figure 4-1, is a strong acid because it completely dissociates in water to make hydronium ions; acetic acid (CH3COOH) only partially dissociates in water and is a weak acid. (The direction of the equilibrium in Figure 4-1 is shown with the larger arrow.)”
+	 */
+
+	/*
+	 * “Svante Arrhenius, a prominent chemist from the early 20th century (whose ideas on acids and bases later earned him the Nobel Prize), defined acids as molecules that dissociate in water to make the hydronium ion, H3O+. Strong Arrhenius acids are those that completely dissociate in water to make hydronium ions, while acids that only partially dissociate in water are said to be weak Arrhenius acids. Nitric acid (HNO3), shown in Figure 4-1, is a strong acid because it completely dissociates in water to make hydronium ions; acetic acid (CH3COOH) only partially dissociates in water and is a weak acid. (The direction of the equilibrium in Figure 4-1 is shown with the larger arrow.)”
 
 Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
 
-    “The Arrhenius definition, though useful, has some “basic” problems. First, the definition can’t apply to all molecules, because many molecules aren’t soluble in water. Second, not all bases dissociate to generate the hydroxide ion. Ammonia (NH3), for example, creates hydroxide ion in solution but has no hydroxide ion in its formula, so it isn’t a basic molecule by virtue of dissociation.
+	“The Arrhenius definition, though useful, has some “basic” problems. First, the definition can’t apply to all molecules, because many molecules aren’t soluble in water. Second, not all bases dissociate to generate the hydroxide ion. Ammonia (NH3), for example, creates hydroxide ion in solution but has no hydroxide ion in its formula, so it isn’t a basic molecule by virtue of dissociation.
 
 Therefore, other acid-base definitions that are more widely applicable are necessary. The most commonly used acid-base definition in organic chemistry is the Brønsted-Lowry definition of acids and bases. A Brønsted-Lowry acid is a molecule that donates a proton (H+) to a base; a Brønsted-Lowry base is a molecule that accepts a proton from an acid.”
 
 Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
-    “To keep the terminology straight, the deprotonated acid becomes what is known as the conjugate base (usually negatively charged, but not always), while the protonated base becomes the conjugate acid, as Figure 4-3 shows.”
+	“To keep the terminology straight, the deprotonated acid becomes what is known as the conjugate base (usually negatively charged, but not always), while the protonated base becomes the conjugate acid, as Figure 4-3 shows.”
 
 Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
 
-    “The most commonly used acid-base definition in organic chemistry is the Brønsted-Lowry definition of acids and bases. A Brønsted-Lowry acid is a molecule that donates a proton (H+) to a base; a Brønsted-Lowry base is a molecule that accepts a proton from an acid.”
+	“The most commonly used acid-base definition in organic chemistry is the Brønsted-Lowry definition of acids and bases. A Brønsted-Lowry acid is a molecule that donates a proton (H+) to a base; a Brønsted-Lowry base is a molecule that accepts a proton from an acid.”
 
-    “To keep the terminology straight, the deprotonated acid becomes what is known as the conjugate base (usually negatively charged, but not always), while the protonated base becomes the conjugate acid, as Figure 4-3 shows.”
-
-
-    The base accepts the H+ proton by furnishing a lone pair of electrons for a coordinate-covalent bond, whish is a covalent bond in which one atom furnishes both of the electrons for the bond. In the coordinate-covalent bond, one atom furnishes both bonding electrons.
-
-Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
-Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
+	“To keep the terminology straight, the deprotonated acid becomes what is known as the conjugate base (usually negatively charged, but not always), while the protonated base becomes the conjugate acid, as Figure 4-3 shows.”
 
 
-    “The most general method for classifying acids and bases is the Lewis acid and base definition. A Lewis acid is a molecule that accepts a pair of electrons to make a covalent bond, and a Lewis base is a molecule that donates electrons to make a covalent bond.”
-
-Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
-
-     */
-    public function isAcid():bool;
-
-    /*
-     * “Arrhenius bases, on the other hand, are molecules that dissociate to make hydroxide ions, OH–. As is the case with acids, bases that dissociate completely to generate hydroxide ions are strong bases, while bases that only partially dissociate to generate hydroxide ions are weak bases. Potassium hydroxide (KOH), shown in Figure 4-2, is a strong base because it completely dissociates in water to make hydroxide ions; beryllium hydroxide (Be[OH]2) is a weak base because it only partially dissociates in water.”
-
-Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
-
-    “The most commonly used acid-base definition in organic chemistry is the Brønsted-Lowry definition of acids and bases. A Brønsted-Lowry acid is a molecule that donates a proton (H+) to a base; a Brønsted-Lowry base is a molecule that accepts a proton from an acid.”
-
-Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
-
-    The base accepts the H+ proton by furnishing a lone pair of electrons for a coordinate-covalent bond, whish is a covalent bond in which one atom furnishes both of the electrons for the bond. In the coordinate-covalent bond, one atom furnishes both bonding electrons.
-
-    eg NH3 + HCl -> NH4 Cl
-
-
-    “To keep the terminology straight, the deprotonated acid becomes what is known as the conjugate base (usually negatively charged, but not always), while the protonated base becomes the conjugate acid, as Figure 4-3 shows.”
-
-Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
-
-    “The most general method for classifying acids and bases is the Lewis acid and base definition. A Lewis acid is a molecule that accepts a pair of electrons to make a covalent bond, and a Lewis base is a molecule that donates electrons to make a covalent bond.”
-
-Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
-     */
-    public function isBase():bool;
-
-
-    /*
-     “The aromatics (or arenes, as they’re often called) consist of rings containing alternating double bonds. The principal aromatic compound is benzene, a six-carbon ring containing three alternating double bonds”
-
-    “Benzene and other aromatics are a highly interesting class of ringed compounds of exceptional stability.”
+	The base accepts the H+ proton by furnishing a lone pair of electrons for a coordinate-covalent bond, whish is a covalent bond in which one atom furnishes both of the electrons for the bond. In the coordinate-covalent bond, one atom furnishes both bonding electrons.
 
 Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
 Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
-     */
-    public function hasBenzeneGroup():bool;
 
 
-    /*
-     “Aromatics are a class of ring compounds containing double bonds. The name aromatic comes from the fact that many of the simple aromatic compounds that were first isolated were highly fragrant; the lovely odors of such substances as vanilla, almond, and wintergreen are due to the presence of aromatic compounds in these products. But many aromatic compounds are unpleasant smelling, or are odorless. Most simple aromatics, in fact, are obtained commercially from coal tar. Aromatic compounds contain double bonds, but they don’t react like alkenes, so they’re classified as a separate functional group. ”
+	“The most general method for classifying acids and bases is the Lewis acid and base definition. A Lewis acid is a molecule that accepts a pair of electrons to make a covalent bond, and a Lewis base is a molecule that donates electrons to make a covalent bond.”
 
-    “Because of this greater stability, aromatic compounds require significantly more vigorous reaction conditions to make them react compared to the conditions required to react simple alkenes.”
+Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
 
-    “The actual structure of benzene is the hybrid of its two resonance structures”
+	 */
+	public function isAcid(): bool;
 
-    “For a molecule to be aromatic, it must meet the following four conditions:
+
+	/*
+	 * “Arrhenius bases, on the other hand, are molecules that dissociate to make hydroxide ions, OH–. As is the case with acids, bases that dissociate completely to generate hydroxide ions are strong bases, while bases that only partially dissociate to generate hydroxide ions are weak bases. Potassium hydroxide (KOH), shown in Figure 4-2, is a strong base because it completely dissociates in water to make hydroxide ions; beryllium hydroxide (Be[OH]2) is a weak base because it only partially dissociates in water.”
+
+Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
+
+	“The most commonly used acid-base definition in organic chemistry is the Brønsted-Lowry definition of acids and bases. A Brønsted-Lowry acid is a molecule that donates a proton (H+) to a base; a Brønsted-Lowry base is a molecule that accepts a proton from an acid.”
+
+Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
+
+	The base accepts the H+ proton by furnishing a lone pair of electrons for a coordinate-covalent bond, whish is a covalent bond in which one atom furnishes both of the electrons for the bond. In the coordinate-covalent bond, one atom furnishes both bonding electrons.
+
+	eg NH3 + HCl -> NH4 Cl
+
+
+	“To keep the terminology straight, the deprotonated acid becomes what is known as the conjugate base (usually negatively charged, but not always), while the protonated base becomes the conjugate acid, as Figure 4-3 shows.”
+
+Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
+
+	“The most general method for classifying acids and bases is the Lewis acid and base definition. A Lewis acid is a molecule that accepts a pair of electrons to make a covalent bond, and a Lewis base is a molecule that donates electrons to make a covalent bond.”
+
+Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
+	 */
+	public function isBase(): bool;
+
+
+	/*
+	 “The aromatics (or arenes, as they’re often called) consist of rings containing alternating double bonds. The principal aromatic compound is benzene, a six-carbon ring containing three alternating double bonds”
+
+	“Benzene and other aromatics are a highly interesting class of ringed compounds of exceptional stability.”
+
+Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
+Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
+	 */
+	public function hasBenzeneGroup(): bool;
+
+
+	/*
+	 “Aromatics are a class of ring compounds containing double bonds. The name aromatic comes from the fact that many of the simple aromatic compounds that were first isolated were highly fragrant; the lovely odors of such substances as vanilla, almond, and wintergreen are due to the presence of aromatic compounds in these products. But many aromatic compounds are unpleasant smelling, or are odorless. Most simple aromatics, in fact, are obtained commercially from coal tar. Aromatic compounds contain double bonds, but they don’t react like alkenes, so they’re classified as a separate functional group. ”
+
+	“Because of this greater stability, aromatic compounds require significantly more vigorous reaction conditions to make them react compared to the conditions required to react simple alkenes.”
+
+	“The actual structure of benzene is the hybrid of its two resonance structures”
+
+	“For a molecule to be aromatic, it must meet the following four conditions:
 
 It must be a ring.
 It must be flat (planar).
 It must have in each atom of the ring a p orbital that’s orthogonal to the plane of the ring. In other words, no atom in the ring can be sp3 hybridized.
 It must have a Hückel number of pi electrons, following the 4n + 2 rule.”
 
-    “If the molecule meets the first three conditions, but only has 4n pi electrons, the molecule is anti-aromatic. If the molecule fails any or all of the first three conditions, then the molecule is non-aromatic. Following are some details about each of these points.”
+	“If the molecule meets the first three conditions, but only has 4n pi electrons, the molecule is anti-aromatic. If the molecule fails any or all of the first three conditions, then the molecule is non-aromatic. Following are some details about each of these points.”
 
-     */
-    public function isAromatic():bool;
+	 */
+	public function isAromatic(): bool;
 
 
-
-    /*
-     Return in order an array of functional groups that the chemical contains.
-     */
-    public function getFunctionalGroups();
+	/*
+	 Return in order an array of functional groups that the chemical contains.
+	 */
+	public function getFunctionalGroups();
 
 
 }

--- a/src/IFunctionalGroup.php
+++ b/src/IFunctionalGroup.php
@@ -1,50 +1,52 @@
 <?php
 
+declare(strict_types=1);
+
 namespace kdaviesnz\molecule;
 
 
 interface IFunctionalGroup
 {
-    /*
-    ref Organic Chemistry 8th Edition.
-    Where bonds to an atom are not speci ed, the atom is assumed to be bonded to one or more carbon or hydrogen atoms in the rest of the molecule.
+	/*
+	ref Organic Chemistry 8th Edition.
+	Where bonds to an atom are not speci ed, the atom is assumed to be bonded to one or more carbon or hydrogen atoms in the rest of the molecule.
 
-    Acid anhydride - RC(=O)OC(=O)R
-    Acid chloride - RC(=O)Cl
-    Alcohol - RCO
-    Aldehyde - RC=O
-    Alkane - CC
-    Alkene - C=C
-    Alkyne - C#C
-    Amide - RC(=O)N
-    Amine, primary - RCN
-    Amine, secondary - RCNCR
-    Amine, tertiary - RCN(RC)CR
-    Carboxylic acid - RC(=O)OH
-    Disulfide - RSSR
-    Epoxide - C1CO1
-    Ester - RC(=O)OC
-    Ether - ROR
-    Haloalkane - RX X 5 F, Cl, Br, I
-    Ketone - RC(=O)R
-    Nitrile - RC#N
-    Nitro - R[N+](=O)[O-]
-    Phenol - C1=CC=C(C=C1)O
-    Sulfide - RSR
-    Thiol - RSH
-     */
+	Acid anhydride - RC(=O)OC(=O)R
+	Acid chloride - RC(=O)Cl
+	Alcohol - RCO
+	Aldehyde - RC=O
+	Alkane - CC
+	Alkene - C=C
+	Alkyne - C#C
+	Amide - RC(=O)N
+	Amine, primary - RCN
+	Amine, secondary - RCNCR
+	Amine, tertiary - RCN(RC)CR
+	Carboxylic acid - RC(=O)OH
+	Disulfide - RSSR
+	Epoxide - C1CO1
+	Ester - RC(=O)OC
+	Ether - ROR
+	Haloalkane - RX X 5 F, Cl, Br, I
+	Ketone - RC(=O)R
+	Nitrile - RC#N
+	Nitro - R[N+](=O)[O-]
+	Phenol - C1=CC=C(C=C1)O
+	Sulfide - RSR
+	Thiol - RSH
+	 */
 
 
-    /*
-     A. Alcohols
-    (RRR)C-OH
+	/*
+	 A. Alcohols
+	(RRR)C-OH
 The functional group of an alcohol is an -OH (hydroxyl) group bonded to a tetra- hedral carbon atom (a carbon having single bonds to four other atoms). Here is the Lewis structure of ethanol. Note that an -OH group is called a hydroxyl, but when attached to a carbon, that combination is referred to as an alcohol group, and the compound is similarly called an alcohol.
 
-    We can also represent this alcohol in a more abbreviated form called a condensed structural formula. In a condensed structural formula, CH3 indicates a carbon bonded to three hydrogens, CH2 indicates a carbon bonded to two hydrogens, and CH indicates a carbon bonded to one hydrogen. Unshared pairs of electrons are generally not shown in a condensed structural formula. Thus, the condensed structural formula for the alcohol with molecular formula C2H6O is CH3-CH2-OH. It is also common to write these formulas in an even more condensed manner by omitting all single bonds: CH3CH2OH.
+	We can also represent this alcohol in a more abbreviated form called a condensed structural formula. In a condensed structural formula, CH3 indicates a carbon bonded to three hydrogens, CH2 indicates a carbon bonded to two hydrogens, and CH indicates a carbon bonded to one hydrogen. Unshared pairs of electrons are generally not shown in a condensed structural formula. Thus, the condensed structural formula for the alcohol with molecular formula C2H6O is CH3-CH2-OH. It is also common to write these formulas in an even more condensed manner by omitting all single bonds: CH3CH2OH.
 
-    Alcohols are classified as primary (1degree), secondary (2degree), or tertiary (3degree) depending on the number of carbon atoms bonded to the carbon bearing the -OH group.
+	Alcohols are classified as primary (1degree), secondary (2degree), or tertiary (3degree) depending on the number of carbon atoms bonded to the carbon bearing the -OH group.
 
-    Primary (1degree)
+	Primary (1degree)
 A compound containing a functional group bonded to a carbon atom bonded to only one other carbon atom and two hydrogens.
 Secondary (2degree)
 A compound containing a functional group bonded to a carbon atom bonded to two other carbon atoms and one hydrogen atom.
@@ -52,18 +54,18 @@ Tertiary (3degree)
 A compound containing a functional group bonded to a carbon atom bonded to three other carbon atoms.
 
 
-    ref Organic Chemistry 8th Edition.
+	ref Organic Chemistry 8th Edition.
 
-     */
+	 */
 
-    /*
-     * Amines
+	/*
+	 * Amines
 
-    RCN
+	RCN
 
-    The functional group of an amine is an amino group, a nitrogen atom bonded to one, two, or three carbon atom(s) by single bonds. In a primary (18) amine, nitrogen is bonded to one carbon atom. In a secondary (28) amine, it is bonded to two carbon atoms, and in a tertiary (38) amine, it is bonded to three carbon atoms. Notice that this classification scheme is different from that used with alcohols and halides.
+	The functional group of an amine is an amino group, a nitrogen atom bonded to one, two, or three carbon atom(s) by single bonds. In a primary (18) amine, nitrogen is bonded to one carbon atom. In a secondary (28) amine, it is bonded to two carbon atoms, and in a tertiary (38) amine, it is bonded to three carbon atoms. Notice that this classification scheme is different from that used with alcohols and halides.
 
-    Amino group
+	Amino group
 A functional group containing a nitrogen atom bonded to one, two, or three carbon atom(s) by single bonds.
 Primary (1degree) amine
 An amine in which nitrogen is bonded to one carbon and two hydrogens.
@@ -72,110 +74,114 @@ An amine in which nitrogen is bonded to two carbons and one hydrogen.
 Tertiary (3degree) amine
 An amine in which nitrogen is
 bonded to three carbons.
-     */
+	 */
 
 
-    /*
-     Aldehydes and Ketones
+	/*
+	 Aldehydes and Ketones
 
-    Aldehyde - RC=O
-    Ketone - RC(=O)R
+	Aldehyde - RC=O
+	Ketone - RC(=O)R
 
 The functional group of both aldehydes and ketones is the C=O (carbonyl) group. In formaldehyde, CH2O, the simplest aldehyde, the carbonyl carbon is bonded to two hydrogens. In all other aldehydes, it is bonded to one hydrogen and one carbon. In a condensed structural formula, the aldehyde group may be writ- ten showing the carbon-oxygen double bond as -CH=O; alternatively, it may be written -CHO. In a ketone, the carbonyl carbon is bonded to two carbon atoms.
 
-    Carbonyl group
+	Carbonyl group
 A C=O group.
 
-     Aldehyde
+	 Aldehyde
 A compound containing a -CHO group.
 
-    Ketone
+	Ketone
 A compound containing a carbonyl group bonded to two carbons.
 
 
-     */
+	 */
 
-    /*
+	/*
 Carboxylic Acids
 
-    Carboxylic acid - RC(=O)OH
+	Carboxylic acid - RC(=O)OH
 
 The functional group of a carboxylic acid is a !COOH (carboxyl: carbonyl 1 hydroxyl) group. In a condensed structural formula, a carboxyl group may also be written -CO2H.
 
-    Carboxylic acid
+	Carboxylic acid
 A compound containing a carboxyl, -COOH, group.
 
-    Carboxyl group
+	Carboxyl group
 A -COOH group.
 
-     */
+	 */
 
-    /*
-        Carboxylic Esters
+	/*
+		Carboxylic Esters
 A carboxylic ester, commonly referred to as an ester, is a derivative of a carboxylic acid in which the hydrogen of the carboxyl group is replaced by a carbon-containing group.
 
-    RC(=O)OC
+	RC(=O)OC
 
-            Carboxylic ester
+			Carboxylic ester
 A derivative of a carboxylic acid in which H of the carboxyl group is replaced by a carbon.
-     */
+	 */
 
-    /*
-     A carboxylic amide, commonly referred to as an amide, is a derivative of a carbox- ylic acid in which the !OH of the carboxyl group is replaced by an amine. As the model shows, the group is planar, something we will explain later
+	/*
+	 A carboxylic amide, commonly referred to as an amide, is a derivative of a carbox- ylic acid in which the !OH of the carboxyl group is replaced by an amine. As the model shows, the group is planar, something we will explain later
 
-    Amide - RC(=O)N
+	Amide - RC(=O)N
 
-    Carboxylic amide
+	Carboxylic amide
 A derivative of a carboxylic acid in which the !OH is replaced by an amine.
 
-     */
+	 */
 
 
-
-    /*
-     “Because alkanes are essentially inert under most conditions, virtually the only reaction of alkanes that you see is the free-radical halogenation reaction. This reaction is often the first reaction that you encounter in organic chemistry.
+	/*
+	 “Because alkanes are essentially inert under most conditions, virtually the only reaction of alkanes that you see is the free-radical halogenation reaction. This reaction is often the first reaction that you encounter in organic chemistry.
 
 The chlorination of methane is shown in Figure 8-20. In this reaction, a chlorine atom is substituted for a methane hydrogen.”
 
-    hv = light
+	hv = light
 
-    Example. CH4 + Cl2  -> hv - > C(H3)Cl (methyl chloride) + HCl (hydorchloric acid
+	Example. CH4 + Cl2  -> hv - > C(H3)Cl (methyl chloride) + HCl (hydorchloric acid
 
-    Initiation
-    In the initiation step, light is shone on the reaction and the radiation is absorbed by the chlorine (Cl2). The light provides enough energy for the married chlorines to divorce — that is, for the chlorine-chlorine bond to break apart to form two chloride radicals, as shown in Figure 8-21. (Recall that free radicals are compounds that contain unpaired electrons.) This kind of bond dissociation is called homolytic cleavage, because the bond breaks symmetrically — one electron “from the bond goes to one side, and the other electron goes to the other side, just as half of the shared property goes to each person in a divorce (theoretically). Note that you use one-headed fishhook arrows to show the movement of only one electron. See Chapter 3 for more on using arrows in organic chemistry.
-     Propagation
-    After the reaction has been initiated by forming the chlorine radicals, the reaction proceeds to the propagation steps (see Figure 8-22). A chlorine radical is unstable because the chlorine atom only has seven valence electrons, one electron short of having its valence octet completely full. To fill its valence octet, a chlorine radical then plucks a hydrogen atom (not a proton) from the methane to make hydrochloric acid plus the methyl radical. Now, however, the methyl radical is one electron short of completing its octet. So, the methyl radical then attacks another molecule of chlorine to make chloromethane plus another chlorine radical.
-     Termination.
-    “Because this reaction generates chlorine radicals as a byproduct, the reaction is called a chain reaction. In a chain reaction, the reactive species (in this case, the chlorine radical) is regenerated by the reaction. If not for the termination steps, this reaction could theoretically continue until all the starting materials were consumed. Termination steps are reactions that remove the reactive species without generating new ones. Any of the radical couplings shown in Figure 8-23 are considered termination steps because they remove the reactive species (the free radicals) from the reaction without replacing them.
+	Initiation
+	In the initiation step, light is shone on the reaction and the radiation is absorbed by the chlorine (Cl2). The light provides enough energy for the married chlorines to divorce — that is, for the chlorine-chlorine bond to break apart to form two chloride radicals, as shown in Figure 8-21. (Recall that free radicals are compounds that contain unpaired electrons.) This kind of bond dissociation is called homolytic cleavage, because the bond breaks symmetrically — one electron “from the bond goes to one side, and the other electron goes to the other side, just as half of the shared property goes to each person in a divorce (theoretically). Note that you use one-headed fishhook arrows to show the movement of only one electron. See Chapter 3 for more on using arrows in organic chemistry.
+	 Propagation
+	After the reaction has been initiated by forming the chlorine radicals, the reaction proceeds to the propagation steps (see Figure 8-22). A chlorine radical is unstable because the chlorine atom only has seven valence electrons, one electron short of having its valence octet completely full. To fill its valence octet, a chlorine radical then plucks a hydrogen atom (not a proton) from the methane to make hydrochloric acid plus the methyl radical. Now, however, the methyl radical is one electron short of completing its octet. So, the methyl radical then attacks another molecule of chlorine to make chloromethane plus another chlorine radical.
+	 Termination.
+	“Because this reaction generates chlorine radicals as a byproduct, the reaction is called a chain reaction. In a chain reaction, the reactive species (in this case, the chlorine radical) is regenerated by the reaction. If not for the termination steps, this reaction could theoretically continue until all the starting materials were consumed. Termination steps are reactions that remove the reactive species without generating new ones. Any of the radical couplings shown in Figure 8-23 are considered termination steps because they remove the reactive species (the free radicals) from the reaction without replacing them.
 
-    What about the chlorination of larger molecules that have different kinds of hydrogens? In methane only one kind of hydrogen is available to be pulled off — and so only one possible product can be made — but in larger molecules, several products can be formed. For example, butane (see Figure 8-24) has two types of hydrogen. Hydrogens are classified according to the substitution of the carbon to which they’re attached. Hydrogens attached to primary carbons (or carbons bonded to only one other carbon) are called primary hydrogens, hydrogens attached to secondary carbons (or carbons bonded to two other carbons) are called secondary hydrogens, and so on. Butane has two types of hydrogens — primary hydrogens (1 degree) and secondary hydrogens (2 degrees).
+	What about the chlorination of larger molecules that have different kinds of hydrogens? In methane only one kind of hydrogen is available to be pulled off — and so only one possible product can be made — but in larger molecules, several products can be formed. For example, butane (see Figure 8-24) has two types of hydrogen. Hydrogens are classified according to the substitution of the carbon to which they’re attached. Hydrogens attached to primary carbons (or carbons bonded to only one other carbon) are called primary hydrogens, hydrogens attached to secondary carbons (or carbons bonded to two other carbons) are called secondary hydrogens, and so on. Butane has two types of hydrogens — primary hydrogens (1 degree) and secondary hydrogens (2 degrees).
 
-    “The chlorination of butane selectively forms the product that results from the chloride radical abstracting a secondary hydrogen to make the secondary radical, as shown in Figure 8-25.”
+	“The chlorination of butane selectively forms the product that results from the chloride radical abstracting a secondary hydrogen to make the secondary radical, as shown in Figure 8-25.”
 
-    “The bromination of alkanes occurs in the same fashion as the chlorination of alkanes, except that Br2 is used in the reaction instead of Cl2. One difference between the chlorination and bromination of alkanes is that bromide radicals are more selective for hydrogen on more substituted carbons than chloride radicals are.”
+	“The bromination of alkanes occurs in the same fashion as the chlorination of alkanes, except that Br2 is used in the reaction instead of Cl2. One difference between the chlorination and bromination of alkanes is that bromide radicals are more selective for hydrogen on more substituted carbons than chloride radicals are.”
 
-    The halogens (/ˈhælədʒən, ˈheɪ-, -loʊ-, -ˌdʒɛn/) are a group in the periodic table consisting of five chemically related elements: fluorine (F), chlorine (Cl), bromine (Br), iodine (I), and astatine (At).
+	The halogens (/ˈhælədʒən, ˈheɪ-, -loʊ-, -ˌdʒɛn/) are a group in the periodic table consisting of five chemically related elements: fluorine (F), chlorine (Cl), bromine (Br), iodine (I), and astatine (At).
 
 Excerpt From: Arthur Winter. “Organic Chemistry I For Dummies.” iBooks.
 
-     */
-    public function freeRadicalHalogenation():array;
+	 */
+	public function freeRadicalHalogenation(): array;
 
-    public function reactions(): array;
 
-    public function prefix(int $carbonCount);
+	public function reactions(): array;
 
-    /*
-        Alkanes have the general molecular formula CnH2n+2
-     */
-    public function molecularFormula(int $carbonCount);
 
-    /*
-     For example, decane, with ten carbon atoms, must have (2 3 10) 1 2 5 22 hydrogen atoms and a molecular formula of C10H22.
-     */
-    public function hydrogenCount(int $carbonCount);
+	public function prefix(int $carbonCount);
 
-    public function carbonBondAngle();
+
+	/*
+		Alkanes have the general molecular formula CnH2n+2
+	 */
+	public function molecularFormula(int $carbonCount);
+
+
+	/*
+	 For example, decane, with ten carbon atoms, must have (2 3 10) 1 2 5 22 hydrogen atoms and a molecular formula of C10H22.
+	 */
+	public function hydrogenCount(int $carbonCount);
+
+
+	public function carbonBondAngle();
 
 
 }

--- a/src/IHydrocarbon.php
+++ b/src/IHydrocarbon.php
@@ -1,6 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace kdaviesnz\molecule;
+
 
 interface IHydrocarbon
 {

--- a/src/IHydrogenHalide.php
+++ b/src/IHydrogenHalide.php
@@ -1,9 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace kdaviesnz\molecule;
 
 
 interface IHydrogenHalide
 {
-
 }

--- a/src/IMethylCarbocation.php
+++ b/src/IMethylCarbocation.php
@@ -1,14 +1,13 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 
+/**
+ * Carbocation with no C-C+ bonds.
+ */
 interface IMethylCarbocation
 {
-
-    /*
-     Carbocation with no C-C+ bonds
-     */
-
 }

--- a/src/IMolecule.php
+++ b/src/IMolecule.php
@@ -1,21 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace kdaviesnz\molecule;
 
 
 interface IMolecule
 {
+	public function isNucleophile(): bool;
 
-    public function isNucleophile():bool;
+	public function isElectrophile(): bool;
 
-    public function isElectrophile():bool;
+	public function isChiral(): bool;
 
-    public function isChiral():bool;
+	public function hasChiralCentre(): bool;
 
-    public function hasChiralCentre():bool;
+	public function getAtoms(): array;
 
-    public function getAtoms():array;
-
-    public function getResonanceStructures():array;
-
+	public function getResonanceStructures(): array;
 }

--- a/src/IPhenylCarbocation.php
+++ b/src/IPhenylCarbocation.php
@@ -1,10 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace kdaviesnz\molecule;
 
+
+/**
+ * If the carbon bearing the positive charge is part of a benzene ring,
+ * the carbocation is termed an aryl carbocation.
+ * The simplest case is called the phenyl carbocation.
+ */
 interface IPhenylCarbocation
 {
-    /*
-     If the carbon bearing the positive charge is part of a benzene ring, the carbocation is termed an aryl carbocation. The simplest case is called the phenyl carbocation.
-     */
 }

--- a/src/IPrimaryCarbocation.php
+++ b/src/IPrimaryCarbocation.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace kdaviesnz\molecule;
 
+
+/**
+ * Carbocation with one C-C+ bond.
+ */
 interface IPrimaryCarbocation
 {
-    /*
-     Carbocation with one C-C+ bond.
-     */
 }

--- a/src/ISaturatedHydrocarbon.php
+++ b/src/ISaturatedHydrocarbon.php
@@ -1,8 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace kdaviesnz\molecule;
+
 
 interface ISaturatedHydrocarbon
 {
-
 }

--- a/src/ISecondaryCarbocation.php
+++ b/src/ISecondaryCarbocation.php
@@ -1,13 +1,13 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 
+/**
+ * Carbocation with two C-C+ bonds.
+ */
 interface ISecondaryCarbocation
 {
-    /*
-     Carbocation with two C-C+ bonds.
-     */
-
 }

--- a/src/ITertiaryCarbocation.php
+++ b/src/ITertiaryCarbocation.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace kdaviesnz\molecule;
 
+/**
+ * Carbocation with 3 C-C+ bonds.
+ */
 interface ITertiaryCarbocation
 {
-    /*
-     Carbocation with 3 C-C+ bonds.
-     */
 }

--- a/src/IUnsaturatedHydrocarbon.php
+++ b/src/IUnsaturatedHydrocarbon.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace kdaviesnz\molecule;
 
 interface IUnsaturatedHydrocarbon
 {
-
 }

--- a/src/IVinylicCarbocation.php
+++ b/src/IVinylicCarbocation.php
@@ -1,11 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace kdaviesnz\molecule;
 
 
+/**
+ * If the carbon bearing the positive charge is part of an alkene, the carbocation is termed a vinylic carbocation.
+ * The simplest case is called the vinyl carbocation.
+ * Note that the carbon bearing the positive charge has two attachments and thus adopts sp hybridization and linear geometry.
+ */
 interface IVinylicCarbocation
 {
-    /*
-     If the carbon bearing the positive charge is part of an alkene, the carbocation is termed a vinylic carbocation. The simplest case is called the vinyl carbocation. Note that the carbon bearing the positive charge has two attachments and thus adopts sp hybridization and linear geometry.
-     */
 }

--- a/src/MethylCarbocation.php
+++ b/src/MethylCarbocation.php
@@ -1,14 +1,14 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 
 class MethylCarbocation extends Carbocation implements IMethylCarbocation
 {
-    public function __construct(MoleculeComponent $molecule)
-    {
-        parent::__construct($molecule);
-    }
-
+	public function __construct(MoleculeComponent $molecule)
+	{
+		parent::__construct($molecule);
+	}
 }

--- a/src/Molecule.php
+++ b/src/Molecule.php
@@ -1,7 +1,9 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
+
 
 use kdaviesnz\atom\IAtom;
 use kdaviesnz\matter\Matter;
@@ -9,46 +11,47 @@ use kdaviesnz\matter\Matter;
 
 class Molecule extends MoleculeComponent
 {
+	public function __construct(array $atoms)
+	{
+		$this->atoms = $atoms;
+	}
 
-    /**
-     * Molecule constructor.
-     */
-    public function __construct(array $atoms)
-    {
-        $this->atoms = $atoms;
-    }
 
-    public function getResonanceStructures():array
-    {
-        return array();
-    }
+	public function getResonanceStructures(): array
+	{
+		return [];
+	}
 
-    public function hasChiralCentre(): bool
-    {
-        // TODO: Implement hasChiralCentre() method.
-        return false;
-    }
 
-    public function isNucleophile(): bool
-    {
-        // TODO: Implement isNucleophile() method.
-        return false;
-    }
+	public function hasChiralCentre(): bool
+	{
+		// TODO: Implement hasChiralCentre() method.
+		return false;
+	}
 
-    public function isElectrophile(): bool
-    {
-        // TODO: Implement isElectrophile() method.
-        return false;
-    }
 
-    public function isChiral(): bool
-    {
-        return false;
-    }
+	public function isNucleophile(): bool
+	{
+		// TODO: Implement isNucleophile() method.
+		return false;
+	}
 
-    public function getAtoms():array
-    {
-        return $this->atoms;
-    }
 
+	public function isElectrophile(): bool
+	{
+		// TODO: Implement isElectrophile() method.
+		return false;
+	}
+
+
+	public function isChiral(): bool
+	{
+		return false;
+	}
+
+
+	public function getAtoms(): array
+	{
+		return $this->atoms;
+	}
 }

--- a/src/MoleculeComponent.php
+++ b/src/MoleculeComponent.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
@@ -6,20 +7,25 @@ namespace kdaviesnz\molecule;
 
 abstract class MoleculeComponent implements IMolecule
 {
+	protected $molecule;
 
-    protected $molecule;
-    protected $atoms = array();
+	protected $atoms = [];
 
-    abstract public function isNucleophile():bool;
 
-    abstract public function isElectrophile():bool;
+	abstract public function isNucleophile(): bool;
 
-    abstract public function isChiral():bool;
 
-    abstract public function hasChiralCentre():bool;
+	abstract public function isElectrophile(): bool;
 
-    abstract public function getAtoms():array;
 
-    abstract function getResonanceStructures():array;
+	abstract public function isChiral(): bool;
 
+
+	abstract public function hasChiralCentre(): bool;
+
+
+	abstract public function getAtoms(): array;
+
+
+	abstract function getResonanceStructures(): array;
 }

--- a/src/MoleculeDecorator.php
+++ b/src/MoleculeDecorator.php
@@ -1,24 +1,23 @@
 <?php
-declare(strict_types=1); // must be first line
 
+declare(strict_types=1);
 
 
 namespace kdaviesnz\molecule;
 
 
-
 abstract class MoleculeDecorator extends MoleculeComponent
 {
 
-    /*
-         abstract public function isNucleophile():bool;
+	/*
+	abstract public function isNucleophile():bool;
 
-    abstract public function isElectrophile():bool;
+	abstract public function isElectrophile():bool;
 
-    abstract public function isChiral():bool;
+	abstract public function isChiral():bool;
 
-    abstract public function hasChiralCentre():bool;
+	abstract public function hasChiralCentre():bool;
 
-    abstract public function getAtoms():array;
-     */
+	abstract public function getAtoms():array;
+	 */
 }

--- a/src/MoleculeFactory.php
+++ b/src/MoleculeFactory.php
@@ -1,21 +1,22 @@
 <?php
-declare(strict_types=1); // must be first line
 
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
+
 
 use kdaviesnz\atom\IAtom;
 
 class MoleculeFactory extends Factory
 {
-    public function __construct(array $atoms)
-    {
-        $this->factoryMethod($atoms);
-    }
+	public function __construct(array $atoms)
+	{
+		$this->factoryMethod($atoms);
+	}
 
-    protected function factoryMethod(array $atoms)
-    {
-        $this->molecule = new Molecule($atoms);
-    }
 
+	protected function factoryMethod(array $atoms)
+	{
+		$this->molecule = new Molecule($atoms);
+	}
 }

--- a/src/Operations.php
+++ b/src/Operations.php
@@ -1,8 +1,8 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
-
 
 
 use kdaviesnz\atom\Atom;
@@ -10,157 +10,160 @@ use kdaviesnz\atom\Bond;
 
 class Operations
 {
+	public function addLoopBonds(array $atoms): array
+	{
+		$bases = [];
+		foreach ($atoms as $k => $atom) {
+			preg_match('/[0-9]*$/', $atom->chem, $matches);
+			if (!empty($matches)) {
+				if (isset($bases[$matches[0]])) {
+					// Add bond
+					$id = uniqid();
+					$atoms[$k]->addBond(new Bond($bases[$matches[0]], $id));
+				} else {
+					$bases[$matches[0]] = $atom;
+				}
+			}
+		}
 
-    public function addLoopBonds(array $atoms):array
-    {
-        $bases = array();
-        foreach ($atoms as $k=>$atom) {
-            preg_match('/[0-9]*$/', $atom->chem, $matches);
-            if (!empty($matches)){
-                if (isset($bases[$matches[0]])) {
-                    // Add bond
-                    $id = uniqid();
-                    $atoms[$k]->addBond(new Bond($bases[$matches[0]], $id));
-                } else {
-                   $bases[$matches[0]] = $atom;
-                }
-            }
-        }
-        return $atoms;
-    }
-
-    public function renderAtomsSimplified(array $atoms):array
-    {
-        $arr = array();
-        foreach($atoms as $key=>$atom) {
-            $bonds = $atom->getBonds();
-            $bondTypes = array();
-            foreach ($bonds as $bond) {
-                $bondTypes[] = $bond->getType() . " " . ($bond->isRecip?"recip":"not recip") . " " . $bond->getId();
-            }
-            $arr[] = array(
-                "chem"=>$atom->chem,
-                "bonds"=>$bondTypes
-            );
-        }
-        return $arr;
-    }
-
-    public function atomsToCanonicalSMILE(array $atoms):string
-    {
-
-        //   $this->displayAtomsSimplified($atoms);
-
-        $firstAtom = array_shift($atoms);
-        $canonicalSMILE = $firstAtom->chem;
-        // First pass - ignore branches
-        if (empty($atoms)) {
-            return $canonicalSMILE;
-        } else {
-            $bonds = $firstAtom->getBonds();
-            $bondType = empty($bonds) || $bonds[0]->getType() == "single"?"":$bonds[0]->getType();
-            $canonicalSMILE.=$bondType;
-        }
-
-        foreach ($atoms as $atom) {
-            $canonicalSMILE .= $atom->chem;
-            $bonds = array_values(array_filter(
-                $atom->getBonds(),
-                function ($bond) {
-                    return !$bond->isRecip;
-                }
-            ));
-            $bondType = empty($bonds) || $bonds[0]->getType() == "single" ? "" : $bonds[0]->getType();
-            $canonicalSMILE .= $bondType;
-        }
+		return $atoms;
+	}
 
 
-        $canonicalSMILE = str_replace(array("double"), array("="), $canonicalSMILE);
+	public function renderAtomsSimplified(array $atoms): array
+	{
+		$arr = [];
+		foreach ($atoms as $key => $atom) {
+			$bonds = $atom->getBonds();
+			$bondTypes = [];
+			foreach ($bonds as $bond) {
+				$bondTypes[] = $bond->getType() . " " . ($bond->isRecip ? "recip" : "not recip") . " " . $bond->getId();
+			}
+			$arr[] = [
+				"chem" => $atom->chem,
+				"bonds" => $bondTypes,
+			];
+		}
 
-        return $canonicalSMILE;
-    }
-
-    public function addBonds(array $atomsToAdd, array $trunkItems)
-    {
-
-        // Find where the single bonds are and add them.
-        for ($i=0;$i<count($trunkItems);$i++) {
-            if ($trunkItems[$i]=="-") {
-                $id = uniqid();
-                $atomsToAdd[$i-1]->addBond(new Bond($atomsToAdd[$i+1], $id, "single"));
-                $atomsToAdd[$i+1]->addBond(new Bond($atomsToAdd[$i-1], $id, "single", 0.00, true));
-            }
-        }
-
-        // Find where the double bonds are and add them.
-        for ($i=0;$i<count($trunkItems);$i++) {
-            if ($trunkItems[$i]=="=") {
-                $id = uniqid();
-                $atomsToAdd[$i-1]->addBond(new Bond($atomsToAdd[$i+1], $id, "double"));
-                $atomsToAdd[$i+1]->addBond(new Bond($atomsToAdd[$i-1], $id, "double", 0.00, true));
-            }
-        }
+		return $arr;
+	}
 
 
-        $atomsToAdd = array_values($atomsToAdd);
+	public function atomsToCanonicalSMILE(array $atoms): string
+	{
+		// TODO: $this->displayAtomsSimplified($atoms);
 
-        return $atomsToAdd;
-    }
+		$firstAtom = array_shift($atoms);
+		$canonicalSMILE = $firstAtom->chem;
+		// First pass - ignore branches
+		if (empty($atoms)) {
+			return $canonicalSMILE;
+		} else {
+			$bonds = $firstAtom->getBonds();
+			$bondType = empty($bonds) || $bonds[0]->getType() == "single" ? "" : $bonds[0]->getType();
+			$canonicalSMILE .= $bondType;
+		}
 
-    public function addBranches(string $canonicalSMILE, array &$atoms, $position=null)
-    {
-
-        preg_match("/\((.*)\)/", $canonicalSMILE, $matches); // First pass CC=C1C
-        if (isset($matches[1])) {
-            $branch = $matches[1]; // First pass ""
-        } else {
-            $branch = "";
-        }
-        $trunk = rtrim(str_replace("(".$branch.")", "", $canonicalSMILE),"-"); // First pass CC=C1C
-        // Add each item in trunk to $atoms array as IAtom and adding bonds between each atom.
-        // "C-C=C-(O-H)"
-        // "C-C=C-(O-H)"
-        preg_match_all("/[A-Z]+[0-9]*|[\-|\=]*/", $trunk, $matches);
-        $trunkItems = array_filter($matches[0]);
-
-        $atomsToAdd = (array_filter(
-            $trunkItems,
-            function($item) {
-                return  ctype_alnum($item);
-            }
-        ));
-
-        $atomsToAdd = array_map(
-            function($item) {
-                return new Atom($item);
-            },
-            $atomsToAdd
-        );
+		foreach ($atoms as $atom) {
+			$canonicalSMILE .= $atom->chem;
+			$bonds = array_values(array_filter(
+				$atom->getBonds(),
+				function ($bond) {
+					return !$bond->isRecip;
+				}
+			));
+			$bondType = empty($bonds) || $bonds[0]->getType() == "single" ? "" : $bonds[0]->getType();
+			$canonicalSMILE .= $bondType;
+		}
 
 
-        $atomsToAdd = $this->addBonds($atomsToAdd, $trunkItems);
+		$canonicalSMILE = str_replace(["double"], ["="], $canonicalSMILE);
 
-        $atoms = array_merge($atoms, $atomsToAdd);
-
-        // Repeat from start for each item in the branch, adding a bond between the atom at $position and the
-        // first atom of the branch.
-        // Keep repeating until there's no more branches.
-
-        if (!empty($canonicalSMILE)) {
-            if (!is_null($position)) {
-                // merge branch
-                $id = uniqid();
-                $atoms[$position]->addBond(new Bond($atomsToAdd[0], $id));
-                $atomsToAdd[0]->addBond(new Bond($atoms[$position], $id, "single", 0.00, true));
-            }
-            $position = strpos(str_replace(array("-", "="), array(""), $canonicalSMILE), "(")-1; // First pass 0
-          //  var_dump($position);
-         //   var_dump($branch);
-           // die();
-            $this->addBranches($branch, $atoms, $position);
-        }
-
-    }
+		return $canonicalSMILE;
+	}
 
 
+	public function addBonds(array $atomsToAdd, array $trunkItems)
+	{
+
+		// Find where the single bonds are and add them.
+		for ($i = 0; $i < count($trunkItems); $i++) {
+			if ($trunkItems[$i] == "-") {
+				$id = uniqid();
+				$atomsToAdd[$i - 1]->addBond(new Bond($atomsToAdd[$i + 1], $id, "single"));
+				$atomsToAdd[$i + 1]->addBond(new Bond($atomsToAdd[$i - 1], $id, "single", 0.00, true));
+			}
+		}
+
+		// Find where the double bonds are and add them.
+		for ($i = 0; $i < count($trunkItems); $i++) {
+			if ($trunkItems[$i] == "=") {
+				$id = uniqid();
+				$atomsToAdd[$i - 1]->addBond(new Bond($atomsToAdd[$i + 1], $id, "double"));
+				$atomsToAdd[$i + 1]->addBond(new Bond($atomsToAdd[$i - 1], $id, "double", 0.00, true));
+			}
+		}
+
+
+		$atomsToAdd = array_values($atomsToAdd);
+
+		return $atomsToAdd;
+	}
+
+
+	public function addBranches(string $canonicalSMILE, array &$atoms, $position = null)
+	{
+		preg_match("/\((.*)\)/", $canonicalSMILE, $matches); // First pass CC=C1C
+
+		if (isset($matches[1])) {
+			$branch = $matches[1]; // First pass ""
+		} else {
+			$branch = "";
+		}
+
+		$trunk = rtrim(str_replace("(" . $branch . ")", "", $canonicalSMILE), "-"); // First pass CC=C1C
+		// Add each item in trunk to $atoms array as IAtom and adding bonds between each atom.
+		// "C-C=C-(O-H)"
+		// "C-C=C-(O-H)"
+		preg_match_all("/[A-Z]+[0-9]*|[\-|\=]*/", $trunk, $matches);
+		$trunkItems = array_filter($matches[0]);
+
+		$atomsToAdd = (array_filter(
+			$trunkItems,
+			function ($item) {
+				return ctype_alnum($item);
+			}
+		));
+
+		$atomsToAdd = array_map(
+			function ($item) {
+				return new Atom($item);
+			},
+			$atomsToAdd
+		);
+
+
+		$atomsToAdd = $this->addBonds($atomsToAdd, $trunkItems);
+
+		$atoms = array_merge($atoms, $atomsToAdd);
+
+		// Repeat from start for each item in the branch, adding a bond between the atom at $position and the
+		// first atom of the branch.
+		// Keep repeating until there's no more branches.
+
+		if (!empty($canonicalSMILE)) {
+			if (!is_null($position)) {
+				// merge branch
+				$id = uniqid();
+				$atoms[$position]->addBond(new Bond($atomsToAdd[0], $id));
+				$atomsToAdd[0]->addBond(new Bond($atoms[$position], $id, "single", 0.00, true));
+			}
+			$position = strpos(str_replace(["-", "="], [""], $canonicalSMILE), "(") - 1; // First pass 0
+			//  var_dump($position);
+			//   var_dump($branch);
+			// die();
+			$this->addBranches($branch, $atoms, $position);
+		}
+
+	}
 }

--- a/src/PhenylCarbocation.php
+++ b/src/PhenylCarbocation.php
@@ -1,14 +1,14 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 
 class PhenylCarbocation extends ArylCarbocation implements IPhenylCarbocation
 {
-
-    public function __construct(MoleculeComponent $molecule)
-    {
-        parent::__construct($molecule);
-    }
+	public function __construct(MoleculeComponent $molecule)
+	{
+		parent::__construct($molecule);
+	}
 }

--- a/src/PrimaryCarbocation.php
+++ b/src/PrimaryCarbocation.php
@@ -1,15 +1,14 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 
 class PrimaryCarbocation extends Carbocation implements IPrimaryCarbocation
 {
-
-    public function __construct(MoleculeComponent $molecule)
-    {
-        parent::__construct($molecule);
-    }
-
+	public function __construct(MoleculeComponent $molecule)
+	{
+		parent::__construct($molecule);
+	}
 }

--- a/src/SaturatedHydrocarbon.php
+++ b/src/SaturatedHydrocarbon.php
@@ -1,43 +1,44 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 
 class SaturatedHydrocarbon extends Hydrocarbon implements ISaturatedHydrocarbon
 {
+	public function __construct(MoleculeComponent $molecule)
+	{
+		parent::__construct($molecule);
+	}
 
-    /**
-     * SaturatedHydrocarbon constructor.
-     */
-    public function __construct(MoleculeComponent $molecule)
-    {
-        parent::__construct($molecule);
-    }
 
-    public function freeRadicalHalogenation(): array
-    {
-        // TODO: Implement freeRadicalHalogenation() method.
-    }
+	public function freeRadicalHalogenation(): array
+	{
+		// TODO: Implement freeRadicalHalogenation() method.
+	}
 
-    public function carbonBondAngle()
-    {
-        // TODO: Implement carbonBondAngle() method.
-    }
 
-    public function prefix(int $carbonCount)
-    {
-        // TODO: Implement prefix() method.
-    }
+	public function carbonBondAngle()
+	{
+		// TODO: Implement carbonBondAngle() method.
+	}
 
-    public function hydrogenCount(int $carbonCount)
-    {
-        // TODO: Implement hydrogenCount() method.
-    }
 
-    public function molecularFormula(int $carbonCount)
-    {
-        // TODO: Implement molecularFormula() method.
-    }
+	public function prefix(int $carbonCount)
+	{
+		// TODO: Implement prefix() method.
+	}
 
+
+	public function hydrogenCount(int $carbonCount)
+	{
+		// TODO: Implement hydrogenCount() method.
+	}
+
+
+	public function molecularFormula(int $carbonCount)
+	{
+		// TODO: Implement molecularFormula() method.
+	}
 }

--- a/src/SecondaryCarbocation.php
+++ b/src/SecondaryCarbocation.php
@@ -1,16 +1,14 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 
-
 class SecondaryCarbocation extends Carbocation implements ISaturatedHydrocarbon
 {
-
-    public function __construct(MoleculeComponent $molecule)
-    {
-        parent::__construct($molecule);
-    }
-
+	public function __construct(MoleculeComponent $molecule)
+	{
+		parent::__construct($molecule);
+	}
 }

--- a/src/TertiaryCarbocation.php
+++ b/src/TertiaryCarbocation.php
@@ -1,15 +1,14 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 
 class TertiaryCarbocation extends Carbocation implements ITertiaryCarbocation
 {
-
-    public function __construct(MoleculeComponent $molecule)
-    {
-        parent::__construct($molecule);
-    }
-
+	public function __construct(MoleculeComponent $molecule)
+	{
+		parent::__construct($molecule);
+	}
 }

--- a/src/UnsaturatedHydrocarbon.php
+++ b/src/UnsaturatedHydrocarbon.php
@@ -1,43 +1,44 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 
 class UnsaturatedHydrocarbon extends Hydrocarbon
 {
+	public function __construct(MoleculeComponent $molecule)
+	{
+		parent::__construct($molecule);
+	}
 
-    /**
-     * UnsaturatedHydrocarbon constructor.
-     */
-    public function __construct(MoleculeComponent $molecule)
-    {
-        parent::__construct($molecule);
-    }
 
-    public function freeRadicalHalogenation(): array
-    {
-        // TODO: Implement freeRadicalHalogenation() method.
-    }
+	public function freeRadicalHalogenation(): array
+	{
+		// TODO: Implement freeRadicalHalogenation() method.
+	}
 
-    public function molecularFormula(int $carbonCount)
-    {
-        // TODO: Implement molecularFormula() method.
-    }
 
-    public function carbonBondAngle()
-    {
-        // TODO: Implement carbonBondAngle() method.
-    }
+	public function molecularFormula(int $carbonCount)
+	{
+		// TODO: Implement molecularFormula() method.
+	}
 
-    public function hydrogenCount(int $carbonCount)
-    {
-        // TODO: Implement hydrogenCount() method.
-    }
 
-    public function prefix(int $carbonCount)
-    {
-        // TODO: Implement prefix() method.
-    }
+	public function carbonBondAngle()
+	{
+		// TODO: Implement carbonBondAngle() method.
+	}
 
+
+	public function hydrogenCount(int $carbonCount)
+	{
+		// TODO: Implement hydrogenCount() method.
+	}
+
+
+	public function prefix(int $carbonCount)
+	{
+		// TODO: Implement prefix() method.
+	}
 }

--- a/src/VinylicCarbocation.php
+++ b/src/VinylicCarbocation.php
@@ -1,14 +1,14 @@
 <?php
-declare(strict_types=1); // must be first line
+
+declare(strict_types=1);
 
 namespace kdaviesnz\molecule;
 
 
 class VinylicCarbocation extends Carbocation implements IVinylicCarbocation
 {
-
-    public function __construct(MoleculeComponent $molecule)
-    {
-        parent::__construct($molecule);
-    }
+	public function __construct(MoleculeComponent $molecule)
+	{
+		parent::__construct($molecule);
+	}
 }


### PR DESCRIPTION
## Description

Master code style fix and upgrade compatibility for PHP 7.1.

## Motivation and context

I am making best fullstack science systen in PHP for Math, Chemistry and more.

Link: https://github.com/mathematicator-core

I think this package can be used as base of Chemic logic.

## How has this been tested?

I want use PhpStan and automated codestyle test in next pullrequest, when you accept this.

## Types of changes

- fully back compatible
- codestyle only
